### PR TITLE
Add Stackelberg Mean Field Games paper (2509.15392)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -15,6 +15,7 @@
 - [Less is More: Recursive Reasoning with Tiny Networks](https://arxiv.org/pdf/2510.04871)
 
 ### 2025.09
+- [Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis](https://arxiv.org/pdf/2509.15392)
 - [Federated Learning with Ad-hoc Adapter Insertions: The Case of Soft-Embeddings for Training Classifier-as-Retriever](https://arxiv.org/pdf/2509.16508)
 - [An AI system to help scientists write expert-level empirical software](https://arxiv.org/pdf/2509.06503)
 - [REFRAG: Rethinking RAG based Decoding](https://arxiv.org/pdf/2509.01092)

--- a/learning/phase-05-reasoning.md
+++ b/learning/phase-05-reasoning.md
@@ -46,6 +46,9 @@
 5. [Small Language Models are the Future of Agentic AI](https://arxiv.org/abs/2506.02153) (2025)
    - *Why*: Makes the case for using smaller, specialized models in agent systems for efficiency and cost-effectiveness; practical deployment considerations
 
+6. [Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis](https://arxiv.org/pdf/2509.15392) (Zeng et al., 2025)
+   - *Why*: Introduces AC-SMFG, a single-loop actor-critic algorithm for hierarchical multi-agent systems with a leader and infinite population of followers; first Stackelberg MFG algorithm with non-asymptotic convergence guarantees; addresses policy optimization in strategic interactions like optimal liquidation and public policy
+
 ---
 
 **Next**: [Phase 6: Novel Architectures & Theory →](phase-06-architectures.md)


### PR DESCRIPTION
## Summary

This PR adds the paper "Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis" (arXiv:2509.15392) to the repository.

## Changes

- Added paper to `by-date.md` under September 2025 (2025.09)
- Added paper to `learning/phase-05-reasoning.md` in the Agentic Systems section (5.2)

## Paper Details

- **Title**: Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis
- **Authors**: Sihan Zeng, Benjamin Patrick Evans, Sujay Bhatt, Leo Ardon, Sumitra Ganesh, Alec Koppel
- **Institution**: J.P.Morgan AI Research
- **Year**: 2025
- **arXiv**: [2509.15392](https://arxiv.org/pdf/2509.15392)

## Why This Paper?

This paper introduces AC-SMFG, a single-loop actor-critic algorithm for hierarchical multi-agent systems with a leader and infinite population of followers. It's the first Stackelberg MFG algorithm with non-asymptotic convergence guarantees and addresses policy optimization in strategic interactions like optimal liquidation and public policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the Stackelberg Mean Field Games paper (arXiv:2509.15392) to `by-date.md` and Phase 5 Agentic Systems with a brief rationale.
> 
> - **Content Updates**:
>   - `by-date.md`: Add `Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis` under `2025.09`.
>   - `learning/phase-05-reasoning.md` (Section 5.2 Agentic Systems): Add the same paper with a brief "Why" note on AC-SMFG and non-asymptotic convergence guarantees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a990d895a7833ef5ac20521df6da463608ef37c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->