### PR TITLE
feat: Add mHC paper and fix Phase 8 numbering

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -3,6 +3,7 @@
 ## 2025
 
 ### 2025.12
+- [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880)
 - 📄 [New York State A6453A/S6953B: Training and Use of Artificial Intelligence Frontier Models](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (Signed December 2025)
 
 ### 2025.11

--- a/learning/phase-06-architectures.md
+++ b/learning/phase-06-architectures.md
@@ -34,6 +34,9 @@
 9. [Order Matters: Sequence to Sequence for Sets](https://arxiv.org/abs/1511.06391) (Vinyals et al., 2015)
    - *Why*: **Handling set-structured data** - extends sequence-to-sequence models to handle unordered sets; important for tasks like set prediction and permutation-invariant learning
 
+10. [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880) (Xie et al., 2025)
+   - *Why*: **Extends Hyper-Connections with stability guarantees** - projects residual connection space onto a constrained manifold to restore identity mapping property; addresses training instability and scalability issues in HC while maintaining performance gains; demonstrates effectiveness at scale (3B-27B models) with improved stability
+
 ## 6.2 Theoretical Foundations
 **Goal**: Understand the mathematical foundations
 

--- a/learning/phase-08-security.md
+++ b/learning/phase-08-security.md
@@ -55,10 +55,10 @@ As AI systems control increasingly important decisions—from content moderation
 1. [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://arxiv.org/abs/2209.07858) (Ganguli et al., 2022)
    - *Why*: **Foundational red teaming paper** from Anthropic - systematic approach to discovering harmful outputs through adversarial probing; demonstrates how red teaming scales with model size; essential methodology for safety evaluation
 
-3. [Automated Red Teaming with GOAT: the Generative Offensive Agent Tester](https://arxiv.org/abs/2410.01606) (Pavlova et al., 2024)
+2. [Automated Red Teaming with GOAT: the Generative Offensive Agent Tester](https://arxiv.org/abs/2410.01606) (Pavlova et al., 2024)
    - *Why*: Agentic red teaming system that simulates multi-turn adversarial conversations using 7 attack techniques; achieves 97% ASR against Llama 3.1 and 88% against GPT-4-Turbo; demonstrates how combining jailbreak methods in conversation outperforms single-prompt attacks
 
-4. [HarmBench: A Standardized Evaluation Framework for Automated Red Teaming and Robust Refusal](https://arxiv.org/abs/2402.04249) (Mazeika et al., 2024)
+3. [HarmBench: A Standardized Evaluation Framework for Automated Red Teaming and Robust Refusal](https://arxiv.org/abs/2402.04249) (Mazeika et al., 2024)
    - *Why*: **Comprehensive safety benchmark** - standardized evaluation for automated red teaming; includes 510 harmful behaviors across semantic categories; enables reproducible comparison of attack and defense methods
 
 4. [WildGuard: Open One-Stop Moderation Tools for Safety Risks, Jailbreaks, and Refusals of LLMs](https://arxiv.org/abs/2406.18495) (Han et al., 2024)


### PR DESCRIPTION
## Summary

Adds the mHC (Manifold-Constrained Hyper-Connections) paper and fixes a numbering issue in Phase 8.

## Changes

### 📄 New Paper
- **mHC: Manifold-Constrained Hyper-Connections** (Xie et al., 2025)
  - Added to Phase 6.1 (Alternative Architectures) as item #10
  - Added to by-date.md under 2025.12
  - Extends Hyper-Connections with stability guarantees by projecting residual connection space onto a constrained manifold

### 🔧 Bug Fix
- Fixed numbering in Phase 8.3 (Safety Evaluation & Red Teaming):
  - GOAT: 3 → 2
  - HarmBench: 4 → 3  
  - WildGuard: duplicate 4 → 4
  - TruthfulQA: 5 (unchanged)
  - WMDP: 6 (unchanged)

## Verification
- ✅ All phase numbering verified across all 13 phases
- ✅ Paper added to correct chronological location
- ✅ Numbering sequence corrected