### PR TITLE
Add Engram paper to Phase 4: Retrieval & Knowledge Systems

### DIFF
--- a/learning/phase-04-retrieval.md
+++ b/learning/phase-04-retrieval.md
@@ -34,6 +34,9 @@
 9. [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172) (Liu et al., 2023)
    - *Why*: **Critical analysis of long-context usage** - reveals U-shaped performance curve where models struggle with information in the middle of long contexts; important for RAG system design
 
+10. [Engram: Conditional Memory via Scalable Lookup](https://github.com/deepseek-ai/Engram/blob/main/Engram_paper.pdf) (Cheng et al., 2025)
+    - *Why*: **Novel memory-augmented architecture** - introduces conditional memory as a new sparsity axis complementing MoE; uses N-gram embeddings for O(1) lookup to retrieve static knowledge, freeing attention for global context and improving both knowledge retrieval and reasoning
+
 ## 4.2 Federated & Distributed Learning
 **Goal**: Train models across distributed data
 


### PR DESCRIPTION
## Summary
Adds DeepSeek's Engram paper to Phase 4: Retrieval & Knowledge Systems.

## Paper Details
- **Title**: Engram: Conditional Memory via Scalable Lookup: A New Axis of Sparsity for Large Language Models
- **Authors**: Cheng et al. (DeepSeek-AI / Peking University)
- **Year**: 2025
- **Link**: https://github.com/deepseek-ai/Engram/blob/main/Engram_paper.pdf

## Key Contributions
- Introduces **conditional memory** as a new axis of sparsity complementing MoE
- Uses N-gram embeddings for O(1) lookup to retrieve static knowledge
- Frees up attention capacity for global context
- Improves both knowledge retrieval (MMLU +3.4) and reasoning (BBH +5.0)
- Enables 100B+ parameter tables with negligible overhead via prefetching

## Changes
- Added paper as entry #10 in section 4.1 (RAG)
- Verified numbering is correct