### PR TITLE
Restructure from phases to areas + tracks, add H-Neurons paper

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.yml
+++ b/.github/ISSUE_TEMPLATE/broken-link.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Location in Repository
       description: Which file contains this link?
-      placeholder: "learning/phase-02-llms.md"
+      placeholder: "learning/language-models.md"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/paper-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/paper-suggestion.yml
@@ -45,25 +45,25 @@ body:
       required: true
 
   - type: dropdown
-    id: phase
+    id: area
     attributes:
-      label: Suggested Learning Phase
-      description: Which phase does this paper best fit into?
+      label: Suggested Area
+      description: Which topic area does this paper best fit into?
       options:
-        - "Phase 1: Foundations"
-        - "Phase 2: Large Language Models"
-        - "Phase 3: Attention & Context"
-        - "Phase 4: Retrieval & RAG"
-        - "Phase 5: Reasoning & Agents"
-        - "Phase 6: Novel Architectures"
-        - "Phase 7: Interpretability"
-        - "Phase 8: Security & Safety"
-        - "Phase 9: Advanced Topics"
-        - "Phase 10: Probabilistic Models"
-        - "Phase 11: Vision & Multimodal"
-        - "Phase 12: Hardware & Systems"
-        - "Phase 13: Policy & Governance"
-        - "Not sure / Multiple phases"
+        - "Foundations"
+        - "Language Models"
+        - "Attention & Context"
+        - "Retrieval & RAG"
+        - "Reasoning & Agents"
+        - "Architectures"
+        - "Interpretability"
+        - "Safety"
+        - "Advanced Topics"
+        - "Probabilistic Models"
+        - "Vision & Multimodal"
+        - "Hardware & Systems"
+        - "Policy & Governance"
+        - "Not sure / Multiple areas"
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@
 |-------|-------|
 | Paper Title | |
 | Link | |
-| Phase | |
+| Area | |
 | Year | |
 
 **Why this paper should be included:**
@@ -45,7 +45,7 @@
 <!-- Check all that apply -->
 
 - [ ] I have checked that links work
-- [ ] Papers are added to both the phase file AND `by-date.md`
+- [ ] Papers are added to both the area file AND `by-date.md`
 - [ ] New papers include a "Why" annotation
 - [ ] I have followed the style guidelines in CONTRIBUTING.md
 - [ ] I have checked for typos

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,24 +46,24 @@ We prioritize papers that meet these criteria:
 - [ ] **Well-scoped** - Focused contribution that's digestible
 - [ ] **Reproducible** - Methods described in enough detail to replicate
 
-### Phase Fit
-Consider which learning phase the paper belongs to:
+### Area Fit
+Consider which topic area the paper belongs to:
 
-| Phase | Focus Area | Example Papers |
-|-------|------------|----------------|
-| 1 | Foundations | LeNet, AlexNet, Word2Vec |
-| 2 | LLMs | BERT, GPT-3, Transformers |
-| 3 | Attention | FlashAttention, RetNet |
-| 4 | Retrieval | RAG, Dense Passage Retrieval |
-| 5 | Reasoning & Agents | ReAct, RLHF, Constitutional AI |
-| 6 | Architectures | Mamba, KAN, Neural Turing Machines |
-| 7 | Interpretability | LIME, Integrated Gradients |
-| 8 | Security | Prompt injection, Adversarial ML |
-| 9 | Advanced | AI Scientist, Multimodal |
-| 10 | Probabilistic | Diffusion, Bayesian methods |
-| 11 | Vision | ViT, CLIP, SAM |
-| 12 | Hardware | Photonics, VLSI |
-| 13 | Policy | GDPR, EU AI Act, NIST RMF |
+| Area | Focus | Example Papers |
+|------|-------|----------------|
+| Foundations | Deep learning basics | LeNet, AlexNet, Word2Vec |
+| Language Models | LLMs | BERT, GPT-3, Transformers |
+| Attention | Efficient attention | FlashAttention, RetNet |
+| Retrieval | RAG, retrieval | RAG, Dense Passage Retrieval |
+| Reasoning | Reasoning & agents | ReAct, RLHF, Constitutional AI |
+| Architectures | Alternative architectures | Mamba, KAN, Neural Turing Machines |
+| Interpretability | Interpretability & evaluation | LIME, Integrated Gradients |
+| Safety | Security & safety | Prompt injection, Adversarial ML |
+| Advanced | Advanced applications | AI Scientist, Multimodal |
+| Probabilistic | Probabilistic models | Diffusion, Bayesian methods |
+| Vision | Vision & multimodal | ViT, CLIP, SAM |
+| Hardware | Hardware & systems | Photonics, VLSI |
+| Policy | Policy & governance | GDPR, EU AI Act, NIST RMF |
 
 ---
 
@@ -76,7 +76,7 @@ Consider which learning phase the paper belongs to:
 3. Fill in:
    - Paper title and link (arXiv preferred)
    - Authors and publication year
-   - Suggested learning phase
+   - Suggested area
    - Why this paper should be included
    - A "Why read this?" annotation (1-2 sentences)
 
@@ -86,7 +86,7 @@ If you're comfortable with Git:
 
 1. Fork the repository
 2. Create a branch: `git checkout -b add-paper-<short-name>`
-3. Add the paper to the appropriate phase file
+3. Add the paper to the appropriate area file (in `learning/`)
 4. Add to `by-date.md` in the correct chronological position
 5. Submit a pull request using the template
 
@@ -134,7 +134,7 @@ For larger changes:
 
 ### Markdown Formatting
 
-- Use `###` for paper titles within phase files
+- Use `###` for paper titles within area files
 - Use emoji indicators:
   - 📄 for research papers
   - 🔒 for paywalled content

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A curated, pedagogically-organized collection of essential research papers spanning the landscape of modern artificial intelligence and machine learning.
 
 [![Papers](https://img.shields.io/badge/papers-150+-blue.svg)](by-date.md)
-[![Learning Path](https://img.shields.io/badge/learning-13_phases-green.svg)](learning-path.md)
+[![Learning Path](https://img.shields.io/badge/learning-13_areas-green.svg)](learning-path.md)
 [![Glossary](https://img.shields.io/badge/glossary-250+_terms-purple.svg)](learning/glossary.md)
 
 ---
@@ -12,30 +12,30 @@
 
 This repository contains **150+ carefully selected research papers** organized in three complementary ways:
 
-1. **📚 [Structured Learning Path](learning-path.md)** - A 13-phase curriculum designed to take you from foundations to cutting-edge research
+1. **📚 [Structured Learning Path](learning-path.md)** - Topic areas and curated tracks from foundations to cutting-edge research
 2. **📅 [Chronological Timeline](by-date.md)** - Papers organized by publication date (1997-2025)
 3. **📖 [Comprehensive Glossary](learning/glossary.md)** - 250+ terms, concepts, and acronyms explained with context
 
-**Plus**: [Recommended reading strategies](#-how-to-use-this-repository), [notes on learning](#paper-reading-tips), and [quick start guides](#-quick-start) tailored to your role (beginner, practitioner, researcher, engineer, security specialist).
+**Plus**: [Recommended tracks](#-how-to-use-this-repository), [notes on learning](#paper-reading-tips), and [quick start guides](#-quick-start) tailored to your role (beginner, practitioner, researcher, engineer, security specialist).
 
 ---
 
 ## 🚀 Quick Start
 
 ### For Beginners
-Start with the **[Learning Path](learning-path.md)** and follow **Phase 1: Foundations**. Read papers in sequence, focusing on the "Why" explanations. Check the **[Glossary](learning/glossary.md)** whenever you encounter unfamiliar terms.
+Start with the **[Learning Path](learning-path.md)** and follow **Foundations**. Read papers in sequence, focusing on the "Why" explanations. Check the **[Glossary](learning/glossary.md)** whenever you encounter unfamiliar terms.
 
 ### For Practitioners
-Jump to relevant phases:
-- **LLMs & Training**: [Phase 2](learning/phase-02-llms.md)
-- **Efficient Models**: [Phase 3](learning/phase-03-attention.md)
-- **Production AI**: [Phase 4](learning/phase-04-retrieval.md) (RAG), [Phase 8](learning/phase-08-security.md) (Security & Safety)
+Jump to relevant areas:
+- **LLMs & Training**: [Language Models](learning/language-models.md)
+- **Efficient Models**: [Attention](learning/attention.md)
+- **Production AI**: [Retrieval](learning/retrieval.md) (RAG), [Safety](learning/safety.md) (Security & Safety)
 
 ### For Researchers
 Browse the **[Chronological View](by-date.md)** to see latest 2025 research, or deep-dive into:
-- [Phase 6: Alternative Architectures](learning/phase-06-architectures.md)
-- [Phase 7: Interpretability](learning/phase-07-interpretability.md)
-- [Phase 9: Advanced Topics](learning/phase-09-advanced.md)
+- [Alternative Architectures](learning/architectures.md)
+- [Interpretability](learning/interpretability.md)
+- [Advanced Topics](learning/advanced.md)
 
 ### Quick Reference
 **Need a definition?** → Check the **[📖 Glossary](learning/glossary.md)** for 250+ terms organized by category (architectures, training, NLP, security, etc.)
@@ -47,31 +47,31 @@ Browse the **[Chronological View](by-date.md)** to see latest 2025 research, or 
 ### Reading Strategies
 
 **🌱 The Beginner Path** (3-6 months)
-1. Start with [Phase 1: Foundations](learning/phase-01-foundations.md)
+1. Start with [Foundations](learning/foundations.md)
 2. Read key papers: [Attention Is All You Need](https://arxiv.org/abs/1706.03762) → [BERT](https://arxiv.org/abs/1810.04805) → [GPT-3](https://arxiv.org/abs/2005.14165)
 3. Focus on "Why" explanations before diving deep
 4. Take notes on connections between papers
 
 **⚡ The Practitioner Sprint** (1-2 months)
-1. Read Phase 1 summaries for context
-2. Deep-dive: [Phase 2](learning/phase-02-llms.md) + [Phase 3](learning/phase-03-attention.md) + [Phase 4](learning/phase-04-retrieval.md)
+1. Read Foundations summaries for context
+2. Deep-dive: [Language Models](learning/language-models.md) + [Attention](learning/attention.md) + [Retrieval](learning/retrieval.md)
 3. Skim related work sections to understand landscape
 4. Implement key techniques from papers
 
 **🔬 The Researcher Deep-Dive** (Ongoing)
 1. Use [chronological view](by-date.md) for latest research
-2. Focus on specific phases relevant to your research
+2. Focus on specific areas relevant to your research
 3. Read citations and follow paper connections
 4. Compare approaches across different papers
 
 **🛠️ The Engineer Focus** (2-4 weeks)
-1. Priority: [Phase 3](learning/phase-03-attention.md) (Efficiency), [Phase 8](learning/phase-08-security.md) (Security & Safety), [Phase 12](learning/phase-12-hardware.md) (Hardware)
+1. Priority: [Attention](learning/attention.md) (Efficiency), [Safety](learning/safety.md) (Security & Safety), [Hardware](learning/hardware.md)
 2. Focus on implementation details and benchmarks
 3. Note production considerations and trade-offs
 
-**� The Security Specialist** (1-2 weeks)
-1. Core: [Phase 8](learning/phase-08-security.md)
-2. Context: [Phase 2](learning/phase-02-llms.md) (LLM basics), [Phase 5](learning/phase-05-reasoning.md) (Alignment)
+**🛡️ The Security Specialist** (1-2 weeks)
+1. Core: [Safety](learning/safety.md)
+2. Context: [Language Models](learning/language-models.md) (LLM basics), [Reasoning](learning/reasoning.md) (Alignment)
 3. Focus on threat models, defense mechanisms, and safety evaluation
 
 ### Paper Reading Tips
@@ -87,25 +87,25 @@ Browse the **[Chronological View](by-date.md)** to see latest 2025 research, or 
 
 ## 📖 Learning Path Overview
 
-The learning path is organized into **13 progressive phases**, each building on previous knowledge:
+The learning path is organized into **13 topic areas**; use [learning-path.md](learning-path.md) for curated **tracks** (reading sequences by goal).
 
-| Phase | Topic | Papers | Focus |
-|-------|-------|--------|-------|
-| **[1](learning/phase-01-foundations.md)** | 🏗️ **Foundations** | 15 | Deep learning basics, embeddings, CNNs, RNNs, GANs, tokenization |
-| **[2](learning/phase-02-llms.md)** | 🤖 **Large Language Models** | 10 | Transformers, BERT, GPT, training at scale |
-| **[3](learning/phase-03-attention.md)** | ⚡ **Attention Innovations** | 9 | FlashAttention 1 & 2, efficient attention, long context |
-| **[4](learning/phase-04-retrieval.md)** | 🔍 **Retrieval & RAG** | 9 | THE RAG paper, dense retrieval, kNN-LM, semantic search |
-| **[5](learning/phase-05-reasoning.md)** | 🧠 **Reasoning & Agents** | 12 | RLHF, chain-of-thought, agentic systems |
-| **[6](learning/phase-06-architectures.md)** | 🏛️ **Alternative Architectures** | 7 | RWKV, Mamba, state-space models, theory |
-| **[7](learning/phase-07-interpretability.md)** | 🔬 **Interpretability** | 11 | LIME, integrated gradients, weight-sparse circuits |
-| **[8](learning/phase-08-security.md)** | 🛡️ **Security, Safety & Robustness** | 10+ | Alignment, security threats, safety evaluation, bias & fairness, harmful content, long-term safety |
-| **[9](learning/phase-09-advanced.md)** | 🎯 **Advanced Applications** | 7 | Multimodal, scientific AI, test-time compute |
-| **[10](learning/phase-10-probabilistic.md)** | 🎲 **Probabilistic Models** | 6 | Diffusion, probabilistic programming |
-| **[11](learning/phase-11-vision.md)** | 👁️ **Vision & Multimodal** | 10 | ViT, CLIP, SAM, LLaVA, vision-language models |
-| **[12](learning/phase-12-hardware.md)** | ⚙️ **Hardware & Systems** | 4 | GPU optimization, inference scaling, photonic computing |
-| **[13](learning/phase-13-policy.md)** | 📜 **Policy & Governance** | 40+ | GDPR, EU AI Act, NIST AI RMF, OCC model risk guidance |
+| Area | Topic | Papers | Focus |
+|------|-------|--------|-------|
+| **[Foundations](learning/foundations.md)** | 🏗️ **Foundations** | 15 | Deep learning basics, embeddings, CNNs, RNNs, GANs, tokenization |
+| **[Language Models](learning/language-models.md)** | 🤖 **Large Language Models** | 10 | Transformers, BERT, GPT, training at scale |
+| **[Attention](learning/attention.md)** | ⚡ **Attention Innovations** | 9 | FlashAttention 1 & 2, efficient attention, long context |
+| **[Retrieval](learning/retrieval.md)** | 🔍 **Retrieval & RAG** | 9 | THE RAG paper, dense retrieval, kNN-LM, semantic search |
+| **[Reasoning](learning/reasoning.md)** | 🧠 **Reasoning & Agents** | 12 | RLHF, chain-of-thought, agentic systems |
+| **[Architectures](learning/architectures.md)** | 🏛️ **Alternative Architectures** | 7 | RWKV, Mamba, state-space models, theory |
+| **[Interpretability](learning/interpretability.md)** | 🔬 **Interpretability** | 11 | LIME, integrated gradients, weight-sparse circuits |
+| **[Safety](learning/safety.md)** | 🛡️ **Security, Safety & Robustness** | 10+ | Alignment, security threats, safety evaluation, bias & fairness, harmful content, long-term safety |
+| **[Advanced](learning/advanced.md)** | 🎯 **Advanced Applications** | 7 | Multimodal, scientific AI, test-time compute |
+| **[Probabilistic](learning/probabilistic.md)** | 🎲 **Probabilistic Models** | 6 | Diffusion, probabilistic programming |
+| **[Vision](learning/vision.md)** | 👁️ **Vision & Multimodal** | 10 | ViT, CLIP, SAM, LLaVA, vision-language models |
+| **[Hardware](learning/hardware.md)** | ⚙️ **Hardware & Systems** | 4 | GPU optimization, inference scaling, photonic computing |
+| **[Policy](learning/policy.md)** | 📜 **Policy & Governance** | 40+ | GDPR, EU AI Act, NIST AI RMF, OCC model risk guidance |
 
-**Total**: 150+ core papers across 13 phases (plus 40+ policy documents & frameworks)
+**Total**: 150+ core papers across 13 areas (plus 40+ policy documents & frameworks)
 
 ---
 

--- a/by-date.md
+++ b/by-date.md
@@ -3,6 +3,7 @@
 ## 2025
 
 ### 2025.12
+- [H-Neurons: On the Existence, Impact, and Origin of Hallucination-Associated Neurons in LLMs](https://arxiv.org/abs/2512.01797) (Gao et al., Tsinghua, 2025)
 - [Recursive Language Models](https://arxiv.org/abs/2512.24601)
 - [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880)
 - 📄 [New York State A6453A/S6953B: Training and Use of Artificial Intelligence Frontier Models](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (Signed December 2025)

--- a/learning-path.md
+++ b/learning-path.md
@@ -1,110 +1,115 @@
 # Learning Path: AI/ML Research Curriculum
 
-A structured curriculum organizing papers from this collection, designed to build knowledge progressively from foundational concepts to cutting-edge research.
+A structured curriculum organizing papers from this collection. Content is organized by **topic areas** (browse by interest); **tracks** are curated reading sequences for specific goals.
 
 ---
 
 ## 📚 How to Use This Learning Path
 
-This curriculum is organized into **13 progressive phases**, each building on previous knowledge. You can:
+This collection is organized in two complementary ways:
 
-- **Follow sequentially** for a comprehensive understanding
-- **Jump to specific phases** based on your interests or needs
-- **Use multiple reading strategies** (see below) tailored to your role
+- **Areas** = Topic-based paper collections. No implied order—browse any area based on your interests. Each area is in its own file.
+- **Tracks** = Curated reading sequences that suggest an order across areas for a given goal (e.g., "ML Engineer," "Safety Specialist").
 
-Each phase is in a separate file for easier navigation and tracking your progress.
+You can **follow a track** for a guided path, **jump to specific areas** based on interest, or **mix both**.
 
 ---
 
 ## Table of Contents
 
-### Core Curriculum
+### Core Areas
 
-1. **[Phase 1: Foundations (Start Here)](learning/phase-01-foundations.md)**
-   - Deep Learning Basics
-   - Sequence Modeling & Recurrent Networks
-   - Generative Models
+- **[Foundations (Start Here)](learning/foundations.md)**
+  - Deep Learning Basics
+  - Word Embeddings & Representations
+  - Sequence Modeling, Generative Models, Tokenization
 
-2. **[Phase 2: Large Language Models - Core Concepts](learning/phase-02-llms.md)**
-   - LLM Foundations (Transformers, BERT, GPT-3)
-   - Training at Scale (Megatron, ZeRO)
-   - Memory & Efficiency Optimizations
+- **[Large Language Models](learning/language-models.md)**
+  - LLM Foundations (Transformers, BERT, GPT-3)
+  - Training at Scale (Megatron, ZeRO)
+  - Memory & Efficiency Optimizations
 
-3. **[Phase 3: Attention Mechanisms & Context](learning/phase-03-attention.md)**
-   - Efficient Attention (FlashAttention, RetNet)
-   - Long Context & Compression
+- **[Attention Mechanisms & Context](learning/attention.md)**
+  - Efficient Attention (FlashAttention, RetNet)
+  - Long Context & Compression
 
-4. **[Phase 4: Retrieval & Knowledge Systems](learning/phase-04-retrieval.md)**
-   - Retrieval-Augmented Generation (RAG)
-   - Federated & Distributed Learning
+- **[Retrieval & Knowledge Systems](learning/retrieval.md)**
+  - Retrieval-Augmented Generation (RAG)
+  - Federated & Distributed Learning
 
-5. **[Phase 5: AI Reasoning & Agents](learning/phase-05-reasoning.md)**
-   - Reasoning Architectures (RLHF, PPO, ReAct)
-   - Agentic Systems
+- **[Reasoning & Alignment](learning/reasoning.md)**
+  - Teaching Models to Reason (RLHF, PPO, ReAct)
+  - Agentic Systems
 
-6. **[Phase 6: Novel Architectures & Theory](learning/phase-06-architectures.md)**
-   - Alternative Architectures (RWKV, KAN)
-   - Theoretical Foundations (Neural Tangent Kernel)
+- **[Novel Architectures & Theory](learning/architectures.md)**
+  - Alternative Architectures (RWKV, KAN)
+  - Theoretical Foundations (Neural Tangent Kernel)
 
-7. **[Phase 7: Model Interpretability & Evaluation](learning/phase-07-interpretability.md)**
-   - Understanding Model Behavior
-   - Model Evaluation & Robustness (TruthfulQA)
+- **[Interpretability & Evaluation](learning/interpretability.md)**
+  - Understanding Model Behavior
+  - Model Evaluation & Robustness (TruthfulQA)
 
-8. **[Phase 8: Security, Safety & Robustness](learning/phase-08-security.md)**
-   - AI Alignment & Safety Training (InstructGPT, Constitutional AI)
-   - Security Threats & Attacks (jailbreaking, prompt injection)
-   - Safety Evaluation & Red Teaming
-   - Bias, Fairness & Robustness
-   - Harmful Content & Misinformation
-   - Long-term Safety Research
+- **[Security, Safety & Robustness](learning/safety.md)**
+  - AI Alignment & Safety Training (InstructGPT, Constitutional AI)
+  - Security Threats & Attacks (jailbreaking, prompt injection)
+  - Safety Evaluation & Red Teaming
+  - Bias, Fairness & Robustness
+  - Harmful Content & Misinformation
+  - Long-term Safety Research
 
-9. **[Phase 9: Advanced Topics & Frontiers](learning/phase-09-advanced.md)**
-   - Automated AI Research
-   - Specialized Applications
-   - Consciousness & AGI
+- **[Advanced Topics & Applications](learning/advanced.md)**
+  - Automated AI Research
+  - Specialized Applications
+  - Consciousness & AGI
 
-### Specialized Topics
+### Specialized Areas
 
-10. **[Phase 10: Probabilistic & Bayesian Approaches](learning/phase-10-probabilistic.md)**
-    - Probabilistic Programming
-    - Bayesian Deep Learning
+- **[Probabilistic & Bayesian Approaches](learning/probabilistic.md)**
+  - Probabilistic Programming
+  - Diffusion Models
 
-11. **[Phase 11: Computer Vision Specialization (Optional)](learning/phase-11-vision.md)**
-    - Vision Architectures (ViT, CLIP, SAM)
-    - Vision Interpretability
+- **[Vision & Multimodal Systems](learning/vision.md)**
+  - Vision Transformers (ViT, CLIP, SAM)
+  - Multimodal & Speech
+  - Vision Interpretability
 
-12. **[Phase 12: Hardware & Systems](learning/phase-12-hardware.md)**
-   - Hardware-Algorithm Co-design
-   - Specialized AI Hardware
+- **[Hardware & Systems](learning/hardware.md)**
+  - Hardware-Algorithm Co-design
+  - Specialized AI Hardware
 
-13. **[Phase 13: Policy, Safety & Societal Impact](learning/phase-13-policy.md)**
-   - Financial Services & Model Risk Management (OCC 2011-12, SR 11-7)
-   - Data Protection & Privacy Law (GDPR, CCPA)
-   - AI-Specific Legislation (EU AI Act, US Executive Orders)
-   - Risk Management Frameworks (NIST AI RMF, ISO/IEC Standards)
-   - Sector-Specific Guidance (Healthcare, Employment, Criminal Justice)
-   - Dual-Use AI & National Security
-   - Responsible AI & Industry Best Practices
-   - Practical Compliance Tools & Resources
+- **[Policy, Safety & Societal Impact](learning/policy.md)**
+  - Financial Services & Model Risk Management (OCC 2011-12, SR 11-7)
+  - Data Protection & Privacy Law (GDPR, CCPA)
+  - AI-Specific Legislation (EU AI Act, US Executive Orders)
+  - Risk Management Frameworks (NIST AI RMF, ISO/IEC Standards)
+  - Sector-Specific Guidance (Healthcare, Employment, Criminal Justice)
+  - Dual-Use AI & National Security
+  - Responsible AI & Industry Best Practices
+  - Practical Compliance Tools & Resources
 
 ---
 
-## 🎯 Recommended Reading Strategies
+## 🎯 Recommended Tracks
+
+Tracks suggest an order across areas for different goals. Pick one that fits your role or goal, then follow the listed areas in sequence (or skip around as needed).
+
+### Comprehensive Track
+Full curriculum in a logical order: [Foundations](learning/foundations.md) → [Language Models](learning/language-models.md) → [Attention](learning/attention.md) → [Retrieval](learning/retrieval.md) → [Reasoning](learning/reasoning.md) → [Architectures](learning/architectures.md) → [Interpretability](learning/interpretability.md) → [Safety](learning/safety.md) → [Advanced](learning/advanced.md) → [Probabilistic](learning/probabilistic.md) → [Vision](learning/vision.md) → [Hardware](learning/hardware.md) → [Policy](learning/policy.md).
 
 ### For Beginners
-Start with **[Phase 1](learning/phase-01-foundations.md)** and **[Phase 2.1](learning/phase-02-llms.md#21-llm-foundations)**, then explore based on interests.
+Start with [Foundations](learning/foundations.md) and [Language Models — LLM Foundations](learning/language-models.md#llm-foundations), then explore based on interests.
 
-### For ML Practitioners
-Start with **[Phase 2](learning/phase-02-llms.md)** (LLMs), then **[Phase 3](learning/phase-03-attention.md)** (Attention), **[Phase 5](learning/phase-05-reasoning.md)** (Agents), and **[Phase 7](learning/phase-07-interpretability.md)** (Evaluation).
+### ML Practitioner Track
+[Language Models](learning/language-models.md) → [Attention](learning/attention.md) → [Reasoning](learning/reasoning.md) → [Interpretability](learning/interpretability.md). Add [Retrieval](learning/retrieval.md) and [Safety](learning/safety.md) for production-focused work.
 
-### For Researchers
-Follow sequentially but focus deeply on **[Phase 6](learning/phase-06-architectures.md)** (Theory), **[Phase 9](learning/phase-09-advanced.md)** (Frontiers), and your area of interest.
+### Researcher Track
+Follow the Comprehensive track but focus deeply on [Architectures](learning/architectures.md), [Interpretability](learning/interpretability.md), [Advanced](learning/advanced.md), and your area of interest.
 
-### For Engineers/Practitioners
-Prioritize **[Phase 2](learning/phase-02-llms.md)** (Training), **[Phase 3](learning/phase-03-attention.md)** (Efficiency), **[Phase 7](learning/phase-07-interpretability.md)** (Evaluation), and **[Phase 8](learning/phase-08-security.md)** (Security).
+### Engineer Track
+Prioritize [Language Models](learning/language-models.md), [Attention](learning/attention.md), [Interpretability](learning/interpretability.md), [Safety](learning/safety.md), and [Hardware](learning/hardware.md).
 
-### For Security Specialists
-Follow **[Phase 1-2](learning/phase-01-foundations.md)** for foundations, then deep dive into **[Phase 8](learning/phase-08-security.md)**.
+### Security Specialist Track
+[Foundations](learning/foundations.md) and [Language Models](learning/language-models.md) for basics, then deep dive into [Safety](learning/safety.md). Add [Interpretability](learning/interpretability.md) and [Policy](learning/policy.md) for full coverage.
 
 ---
 
@@ -130,16 +135,16 @@ Follow **[Phase 1-2](learning/phase-01-foundations.md)** for foundations, then d
 
 ## 🚀 Quick Start
 
-**New to AI/ML?** → Start with [Phase 1: Foundations](learning/phase-01-foundations.md)
+**New to AI/ML?** → Start with [Foundations](learning/foundations.md)
 
-**Have ML background?** → Jump to [Phase 2: Large Language Models](learning/phase-02-llms.md)
+**Have ML background?** → Jump to [Large Language Models](learning/language-models.md)
 
-**Looking for specific topics?** → Use the TOC above to navigate directly
+**Looking for specific topics?** → Use the TOC above to navigate by area
 
-**Want to build agents?** → Focus on [Phase 5: Reasoning & Agents](learning/phase-05-reasoning.md)
+**Want to build agents?** → Focus on [Reasoning & Agents](learning/reasoning.md)
 
-**Interested in safety?** → Head to [Phase 8: Security, Safety & Robustness](learning/phase-08-security.md)
+**Interested in safety?** → Head to [Security, Safety & Robustness](learning/safety.md)
 
 ---
 
-*Last updated: December 29, 2025*
+*Last updated: March 4, 2026*

--- a/learning/advanced.md
+++ b/learning/advanced.md
@@ -1,10 +1,10 @@
-# Phase 9: Advanced Topics & Applications
+# Advanced Topics & Applications
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 8](phase-08-security.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Safety](safety.md) | [Probabilistic](probabilistic.md)
 
-**Phase Overview**: With strong foundations in place, this phase explores cutting-edge applications and research directions. You'll learn how models handle multiple modalities (text, images, audio) simultaneously, how [test-time compute](glossary.md#test-time-compute) scaling allows models to "think longer" for better results, how to evaluate model outputs effectively, and emerging techniques like inference scaling laws. This phase also covers practical deployment considerations and the shift from pure scaling to more efficient use of compute. These topics represent the current frontier of research and what you might encounter in production systems today.
+**Overview**: With strong foundations in place, this phase explores cutting-edge applications and research directions. You'll learn how models handle multiple modalities (text, images, audio) simultaneously, how [test-time compute](glossary.md#test-time-compute) scaling allows models to "think longer" for better results, how to evaluate model outputs effectively, and emerging techniques like inference scaling laws. This phase also covers practical deployment considerations and the shift from pure scaling to more efficient use of compute. These topics represent the current frontier of research and what you might encounter in production systems today.
 
-## 9.1 Automated AI Research
+## Automated AI Research
 **Goal**: AI systems that can do research
 
 1. [The AI Scientist: Towards Fully Automated Open-Ended Scientific Discovery](https://arxiv.org/pdf/2408.06292) (2024)
@@ -16,7 +16,7 @@
 3. [AlphaGo Moment for Model Architecture Discovery](https://arxiv.org/pdf/2507.18074) (2025)
    - *Why*: Automated neural architecture search
 
-## 9.2 Specialized Applications
+## Specialized Applications
 **Goal**: Apply AI to specific domains
 
 1. [Stable Audio Open](https://arxiv.org/pdf/2407.14358) (2024)
@@ -28,7 +28,7 @@
 3. [TabPFN: A transformer that solves small tabular classification problems in a second](https://arxiv.org/pdf/2207.01848v3.pdf) (2023)
    - *Why*: In-context learning for tabular data
 
-## 9.3 Consciousness & AGI
+## Consciousness & AGI
 **Goal**: Explore philosophical frontiers
 
 1. [Consciousness in Artificial Intelligence: Insights from the Science of Consciousness](https://arxiv.org/pdf/2308.08708v3.pdf) (2024)
@@ -39,4 +39,4 @@
 
 ---
 
-**Next**: [Phase 10: Probabilistic & Bayesian Approaches →](phase-10-probabilistic.md)
+**Related**: [Safety](safety.md) | [Probabilistic](probabilistic.md) | [Vision](vision.md)

--- a/learning/architectures.md
+++ b/learning/architectures.md
@@ -1,10 +1,10 @@
-# Phase 6: Novel Architectures & Theory
+# Novel Architectures & Theory
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Reasoning & Agents](phase-05-reasoning.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Reasoning](reasoning.md) | [Interpretability](interpretability.md)
 
-**Phase Overview**: [Transformers](glossary.md#transformer) dominate modern AI, but are they the final answer? This phase explores alternative architectures that challenge the transformer's supremacy: [state-space models](glossary.md#state-space-model) like [Mamba](glossary.md#mamba) that achieve linear-time inference, [retention networks](glossary.md#retnet-retentive-network) that blend RNN and transformer properties, [RWKV](glossary.md#rwkv)'s parallelizable RNN approach, and hybrid architectures that combine different mechanisms. Each offers different trade-offs between performance, efficiency, and scaling properties. Understanding these alternatives gives you insight into the fundamental principles that make architectures work—and hints at what might come next.
+**Overview**: [Transformers](glossary.md#transformer) dominate modern AI, but are they the final answer? This phase explores alternative architectures that challenge the transformer's supremacy: [state-space models](glossary.md#state-space-model) like [Mamba](glossary.md#mamba) that achieve linear-time inference, [retention networks](glossary.md#retnet-retentive-network) that blend RNN and transformer properties, [RWKV](glossary.md#rwkv)'s parallelizable RNN approach, and hybrid architectures that combine different mechanisms. Each offers different trade-offs between performance, efficiency, and scaling properties. Understanding these alternatives gives you insight into the fundamental principles that make architectures work—and hints at what might come next.
 
-## 6.1 Alternative Architectures
+## Alternative Architectures
 **Goal**: Explore beyond standard transformers
 
 1. [Neural Turing Machines](https://arxiv.org/abs/1410.5401) (Graves et al., 2014)
@@ -37,7 +37,7 @@
 10. [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880) (Xie et al., 2025)
    - *Why*: **Extends Hyper-Connections with stability guarantees** - projects residual connection space onto a constrained manifold to restore identity mapping property; addresses training instability and scalability issues in HC while maintaining performance gains; demonstrates effectiveness at scale (3B-27B models) with improved stability
 
-## 6.2 Theoretical Foundations
+## Theoretical Foundations
 **Goal**: Understand the mathematical foundations
 
 1. [Neural Tangent Kernel: Convergence and Generalization in Neural Networks](https://arxiv.org/abs/1806.07572) (Jacot et al., 2018)
@@ -54,4 +54,4 @@
 
 ---
 
-**Next**: [Phase 7: Model Interpretability & Evaluation →](phase-07-interpretability.md)
+**Related**: [Reasoning](reasoning.md) | [Interpretability](interpretability.md) | [Safety](safety.md)

--- a/learning/attention.md
+++ b/learning/attention.md
@@ -1,10 +1,10 @@
-# Phase 3: Attention Mechanism Innovations
+# Attention Mechanism Innovations
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 2](phase-02-llms.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Language Models](language-models.md) | [Retrieval](retrieval.md)
 
-**Phase Overview**: While [transformers](glossary.md#transformer) are powerful, their quadratic memory and compute complexity with sequence length creates significant bottlenecks. This phase explores ingenious solutions to make [attention](glossary.md#attention-mechanism) more efficient—from [FlashAttention](glossary.md#flashattention)'s IO-aware algorithms that dramatically speed up training, to architectural innovations like linear attention and state-space models that achieve sub-quadratic scaling. These advances are critical for processing long documents, reducing costs, and enabling real-time applications, representing some of the most active areas of current research.
+**Overview**: While [transformers](glossary.md#transformer) are powerful, their quadratic memory and compute complexity with sequence length creates significant bottlenecks. This phase explores ingenious solutions to make [attention](glossary.md#attention-mechanism) more efficient—from [FlashAttention](glossary.md#flashattention)'s IO-aware algorithms that dramatically speed up training, to architectural innovations like linear attention and state-space models that achieve sub-quadratic scaling. These advances are critical for processing long documents, reducing costs, and enabling real-time applications, representing some of the most active areas of current research.
 
-## 3.1 Efficient Attention
+## Efficient Attention
 **Goal**: Understand and optimize the core attention mechanism
 
 1. [FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness](https://arxiv.org/abs/2205.14135) (Dao et al., 2022)
@@ -25,7 +25,7 @@
 6. [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/abs/2502.11089) (2025)
    - *Why*: Hardware-efficient sparse attention
 
-## 3.2 Long Context & Compression
+## Long Context & Compression
 **Goal**: Handle longer sequences efficiently
 
 1. [TriForce: Lossless Acceleration of Long Sequence Generation with Hierarchical Speculative Decoding](https://arxiv.org/pdf/2404.11912v1.pdf) (2024)
@@ -42,4 +42,4 @@
 
 ---
 
-**Next**: [Phase 4: Retrieval & Knowledge Systems →](phase-04-retrieval.md)
+**Related**: [Language Models](language-models.md) | [Retrieval](retrieval.md) | [Architectures](architectures.md)

--- a/learning/foundations.md
+++ b/learning/foundations.md
@@ -1,10 +1,10 @@
-# Phase 1: Foundations (Start Here)
+# Foundations (Start Here)
 
-[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Language Models](language-models.md)
 
-**Phase Overview**: This phase establishes the essential groundwork for understanding modern AI systems. You'll explore the fundamental principles of [deep learning](glossary.md#deep-learning), from basic neural network architectures to the revolutionary [transformer](glossary.md#transformer) model that underpins nearly all current LLMs. By mastering these foundational concepts—including training dynamics, [attention mechanisms](glossary.md#attention-mechanism), and the shift from convolutional to attention-based architectures—you'll build the technical vocabulary and intuition needed for everything that follows. Think of this as learning the alphabet before reading literature.
+**Overview**: This phase establishes the essential groundwork for understanding modern AI systems. You'll explore the fundamental principles of [deep learning](glossary.md#deep-learning), from basic neural network architectures to the revolutionary [transformer](glossary.md#transformer) model that underpins nearly all current LLMs. By mastering these foundational concepts—including training dynamics, [attention mechanisms](glossary.md#attention-mechanism), and the shift from convolutional to attention-based architectures—you'll build the technical vocabulary and intuition needed for everything that follows. Think of this as learning the alphabet before reading literature.
 
-## 1.1 Deep Learning Basics
+## Deep Learning Basics
 **Goal**: Understand the fundamental building blocks of modern deep learning
 
 1. 🔒 [Deep Learning (Nature Review)](https://www.nature.com/articles/nature14539) (LeCun, Bengio, Hinton, 2015)
@@ -40,7 +40,7 @@
    - *Key insight*: Standard pruning naturally uncovers subnetworks whose initializations made them capable of training effectively; these winning tickets are typically 10-20% of the original network size
    - *Impact*: Sparked extensive research into sparse training, initialization strategies, and understanding what makes networks trainable
 
-## 1.2 Word Embeddings & Representations
+## Word Embeddings & Representations
 **Goal**: Learn how words become vectors - the bridge between discrete symbols and continuous neural networks
 
 **Why this matters**: Before transformers, before tokenization strategies, there was a fundamental question: how do we represent words as numbers that neural networks can process? [Word embeddings](glossary.md#embeddings) revolutionized NLP by learning dense vector representations that capture semantic relationships (e.g., "king" - "man" + "woman" ≈ "queen"). Understanding embeddings is crucial for grasping why modern LLMs work - they're doing something far more sophisticated than simple lookup tables.
@@ -73,13 +73,13 @@
 **The Evolution**:
 - **2013**: Word2Vec shows neural embeddings work amazingly well
 - **2014**: GloVe and Seq2Seq show different ways to capture meaning
-- **2017**: Transformers (Phase 2) make embeddings contextual via attention
+- **2017**: Transformers ([Language Models](language-models.md)) make embeddings contextual via attention
 - **2018+**: BERT, GPT show that contextual embeddings are far more powerful
 
 **Bridge to Modern LLMs**: 
 The embeddings in GPT-4 or Claude aren't just fancy Word2Vec - they're contextual representations computed through layers of attention. But Word2Vec taught us the fundamental insight: meaning lives in high-dimensional geometry. Every modern LLM starts with an embedding layer that converts tokens to vectors, then transforms those vectors through attention layers.
 
-## 1.3 Sequence Models
+## Sequence Models
 **Goal**: Learn how to model sequential data
 
 1. 🔒 [Long Short-Term Memory (LSTM)](https://www.researchgate.net/publication/13853244_Long_Short-term_Memory) (1997)
@@ -92,7 +92,7 @@ The embeddings in GPT-4 or Claude aren't just fancy Word2Vec - they're contextua
 3. [MOMENT: A Family of Open Time-series Foundation Models](https://arxiv.org/pdf/2402.03885) (2024)
    - *Why*: Modern approach to time-series with foundation models
 
-## 1.4 Generative Models
+## Generative Models
 **Goal**: Understand how to generate new data
 
 1. [Generative Adversarial Networks](https://arxiv.org/abs/1406.2661) (2014)
@@ -104,7 +104,7 @@ The embeddings in GPT-4 or Claude aren't just fancy Word2Vec - they're contextua
 3. [Dualscale Diffusion: Adaptive Feature Balancing for Low-Dimensional Generative Models](https://sakana.ai/assets/ai-scientist/adaptive_dual_scale_denoising.pdf) (2024)
    - *Why*: Modern diffusion models for generative tasks
 
-## 1.5 Tokenization & Subword Models
+## Tokenization & Subword Models
 **Goal**: Understand how text is broken into tokens - the bridge between raw text and neural networks
 
 **Why this matters**: Before any language model can process text, it must convert words into tokens. This seemingly simple step profoundly impacts model performance, vocabulary size, and the ability to handle rare words, different languages, and out-of-vocabulary terms. Understanding tokenization is essential for grasping why LLMs behave the way they do with certain inputs.
@@ -143,4 +143,4 @@ The embeddings in GPT-4 or Claude aren't just fancy Word2Vec - they're contextua
 
 ---
 
-**Next**: [Phase 2: Large Language Models →](phase-02-llms.md)
+**Related**: [Language Models](language-models.md) | [Attention](attention.md)

--- a/learning/glossary.md
+++ b/learning/glossary.md
@@ -29,7 +29,7 @@ A mathematical function applied to a neuron's output that introduces non-lineari
 The fundamental algorithm for training neural networks by computing gradients of the loss function with respect to each weight. Uses the chain rule to efficiently propagate errors backward through the network.
 
 ### Batch Normalization
-A technique that normalizes layer inputs by re-centering and re-scaling, making training faster and more stable. Introduced in Phase 1, it enables training much deeper networks by reducing internal covariate shift.
+A technique that normalizes layer inputs by re-centering and re-scaling, making training faster and more stable. Introduced in the Foundations area, it enables training much deeper networks by reducing internal covariate shift.
 
 ### Deep Learning
 A subset of machine learning using neural networks with multiple layers (hence "deep"). Excels at automatically learning hierarchical representations from raw data without manual feature engineering.
@@ -341,6 +341,9 @@ How well a model's confidence scores match actual accuracy. A well-calibrated mo
 
 ### Gradient-based Attribution
 Explanation methods using gradients to identify which input features most influence the output. Includes vanilla gradients, Integrated Gradients, SmoothGrad.
+
+### H-Neurons (Hallucination-Associated Neurons)
+A sparse subset of feedforward network (FFN) neurons whose activations reliably predict when an LLM will produce hallucinated rather than faithful outputs. Identified via sparse linear probing on contribution metrics (e.g., CETT); typically &lt;0.1% of model neurons. Causal interventions show they drive over-compliance behaviors (invalid premises, misleading context, sycophancy, harmful instructions). They originate in pre-training rather than alignment. Enables neuron-level hallucination detection and potential intervention points. See [H-Neurons (Gao et al., 2025)](https://arxiv.org/abs/2512.01797).
 
 ### Hallucination
 When language models generate plausible-sounding but factually incorrect information. A major challenge for deploying LLMs in production.

--- a/learning/hardware.md
+++ b/learning/hardware.md
@@ -1,10 +1,10 @@
-# Phase 12: Hardware & Systems
+# Hardware & Systems
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 11](phase-11-vision.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Vision](vision.md) | [Policy](policy.md)
 
-**Phase Overview**: AI doesn't run on theory alone—hardware and systems design fundamentally shape what's possible. This phase examines how memory bandwidth bottlenecks limit model performance, how specialized hardware accelerators exploit AI workload characteristics, and how [distributed training](glossary.md#distributed-training) systems coordinate thousands of [GPUs](glossary.md#gpu-graphics-processing-unit) to train massive models. Understanding the hardware-software co-design is crucial for making informed decisions about model architecture, for optimizing deployment costs, and for anticipating future directions as specialized AI chips become more prevalent.
+**Overview**: AI doesn't run on theory alone—hardware and systems design fundamentally shape what's possible. This phase examines how memory bandwidth bottlenecks limit model performance, how specialized hardware accelerators exploit AI workload characteristics, and how [distributed training](glossary.md#distributed-training) systems coordinate thousands of [GPUs](glossary.md#gpu-graphics-processing-unit) to train massive models. Understanding the hardware-software co-design is crucial for making informed decisions about model architecture, for optimizing deployment costs, and for anticipating future directions as specialized AI chips become more prevalent.
 
-## 12.1 Hardware Considerations
+## Hardware Considerations
 **Goal**: Understand hardware-algorithm co-design
 
 1. [Making Deep Learning Go Brrrr From First Principles](https://horace.io/brrr_intro.html) (He, 2022)
@@ -21,4 +21,4 @@
 
 ---
 
-**Next**: [Phase 13: Policy & Governance →](phase-13-policy.md)
+**Related**: [Vision](vision.md) | [Policy](policy.md) | [Safety](safety.md)

--- a/learning/interpretability.md
+++ b/learning/interpretability.md
@@ -1,10 +1,10 @@
-# Phase 7: Interpretability & Analysis
+# Interpretability & Analysis
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 6](phase-06-architectures.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Architectures](architectures.md) | [Safety](safety.md)
 
-**Phase Overview**: Neural networks are often treated as black boxes, but what's really happening inside? This phase dives into [interpretability](glossary.md#mechanistic-interpretability)—the science of understanding and explaining model behavior. You'll learn about mechanistic interpretability that reverse-engineers learned algorithms, activation analysis techniques like sparse autoencoders that reveal hidden structure, theoretical frameworks like the [Neural Tangent Kernel](glossary.md#neural-tangent-kernel) that explain why deep learning works, and methods for detecting when models are truthful or deceptive. As AI systems become more powerful and deployed in high-stakes settings, interpretability becomes crucial for trust, debugging, and safety.
+**Overview**: Neural networks are often treated as black boxes, but what's really happening inside? This phase dives into [interpretability](glossary.md#mechanistic-interpretability)—the science of understanding and explaining model behavior. You'll learn about mechanistic interpretability that reverse-engineers learned algorithms, activation analysis techniques like sparse autoencoders that reveal hidden structure, theoretical frameworks like the [Neural Tangent Kernel](glossary.md#neural-tangent-kernel) that explain why deep learning works, and methods for detecting when models are truthful or deceptive. As AI systems become more powerful and deployed in high-stakes settings, interpretability becomes crucial for trust, debugging, and safety.
 
-## 7.1 Understanding Model Behavior
+## Understanding Model Behavior
 **Goal**: Interpret what models learn and how they work
 
 1. [Towards A Rigorous Science of Interpretable Machine Learning](https://arxiv.org/abs/1702.08608) (2017)
@@ -34,7 +34,10 @@
 9. [Weight-sparse transformers have interpretable circuits](https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf) (Gao et al., OpenAI, 2025)
    - *Why*: **Training models for interpretability from scratch** - constrains most weights to zero so neurons have few connections; produces circuits with unprecedented human understandability through weight sparsity rather than post-hoc analysis; validates circuits with mean ablation showing they are necessary and sufficient for task performance
 
-## 7.2 Model Evaluation & Robustness
+10. [H-Neurons: On the Existence, Impact, and Origin of Hallucination-Associated Neurons in LLMs](https://arxiv.org/abs/2512.01797) (Gao et al., Tsinghua, 2025)
+   - *Why*: **Neuron-level mechanistic view of hallucinations** - identifies a sparse subset (<0.1%) of feedforward neurons ([H-Neurons](glossary.md#h-neurons-hallucination-associated-neurons)) that reliably predict hallucination; shows they drive over-compliance behaviors (invalid premises, misleading context, sycophancy, harmful instructions) and originate in pre-training; bridges macro-behavioral patterns with micro-neural mechanisms for detection and intervention
+
+## Model Evaluation & Robustness
 **Goal**: Properly evaluate and benchmark models
 
 1. [TruthfulQA: Measuring How Models Mimic Human Falsehoods](https://arxiv.org/abs/2109.07958) (Lin et al., 2022)
@@ -54,4 +57,4 @@
 
 ---
 
-**Next**: [Phase 8: Security, Safety & Robustness →](phase-08-security.md)
+**Related**: [Architectures](architectures.md) | [Safety](safety.md) | [Language Models](language-models.md)

--- a/learning/language-models.md
+++ b/learning/language-models.md
@@ -1,10 +1,10 @@
-# Phase 2: Large Language Models - Core Concepts
+# Large Language Models - Core Concepts
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Foundations](phase-01-foundations.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Foundations](foundations.md) | [Attention](attention.md)
 
-**Phase Overview**: This phase traces the explosive evolution of language models from [BERT](glossary.md#bert-bidirectional-encoder-representations-from-transformers)'s bidirectional pretraining breakthrough to [GPT](glossary.md#gpt-generative-pre-trained-transformer)-3's massive scale demonstration. You'll learn how the field discovered that [pre-training](glossary.md#pre-training) on vast amounts of text data creates models with remarkable [few-shot learning](glossary.md#few-shot-learning) abilities, and how different pretraining objectives (masked language modeling vs. autoregressive) lead to different capabilities. This progression from BERT to GPT-3 to instruction-tuned models forms the backbone of modern NLP and sets the stage for understanding today's ChatGPT-style systems.
+**Overview**: This phase traces the explosive evolution of language models from [BERT](glossary.md#bert-bidirectional-encoder-representations-from-transformers)'s bidirectional pretraining breakthrough to [GPT](glossary.md#gpt-generative-pre-trained-transformer)-3's massive scale demonstration. You'll learn how the field discovered that [pre-training](glossary.md#pre-training) on vast amounts of text data creates models with remarkable [few-shot learning](glossary.md#few-shot-learning) abilities, and how different pretraining objectives (masked language modeling vs. autoregressive) lead to different capabilities. This progression from BERT to GPT-3 to instruction-tuned models forms the backbone of modern NLP and sets the stage for understanding today's ChatGPT-style systems.
 
-## 2.1 LLM Foundations
+## LLM Foundations
 **Goal**: Understand transformer architecture and pre-training
 
 1. [Neural Machine Translation by Jointly Learning to Align and Translate](https://arxiv.org/abs/1409.0473) (Bahdanau et al., 2014)
@@ -34,7 +34,7 @@
 9. [EuroLLM: Multilingual Language Models for Europe](https://arxiv.org/pdf/2409.11741) (2024)
    - *Why*: Multilingual capabilities and cross-lingual transfer
 
-## 2.2 Training at Scale
+## Training at Scale
 **Goal**: Learn how to train massive models efficiently
 
 1. [GPipe: Easy Scaling with Micro-Batch Pipeline Parallelism](https://arxiv.org/abs/1811.06965) (Huang et al., 2019)
@@ -52,7 +52,7 @@
 5. [The Potential of Second-Order Optimization for LLMs: A Study with Full Gauss-Newton](https://arxiv.org/pdf/2510.09378) (2025)
    - *Why*: Advanced optimization techniques for faster convergence
 
-## 2.3 Memory & Efficiency Optimizations
+## Memory & Efficiency Optimizations
 **Goal**: Make models faster and more memory-efficient
 
 1. [Cut Your Losses in Large-Vocabulary Language Models](https://arxiv.org/abs/2411.09009) (2024)
@@ -66,4 +66,4 @@
 
 ---
 
-**Next**: [Phase 3: Attention Mechanisms & Context →](phase-03-attention.md)
+**Related**: [Foundations](foundations.md) | [Attention](attention.md) | [Retrieval](retrieval.md)

--- a/learning/policy.md
+++ b/learning/policy.md
@@ -1,12 +1,12 @@
-# Phase 13: Policy, Safety & Societal Impact
+# Policy, Safety & Societal Impact
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 12](phase-12-hardware.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Hardware](hardware.md) | [Safety](safety.md)
 
-**Phase Overview**: Technical capabilities alone don't determine AI's impact on society—policy, governance, and ethical considerations are equally critical. This final phase steps back to examine the bigger picture: how should AI systems be regulated, what are the existential and near-term risks, how do we ensure equitable access and prevent misuse, and what frameworks exist for responsible AI development? Whether you're building AI systems, advising organizations, or simply want to be an informed citizen, understanding these policy and safety considerations is essential as AI becomes increasingly central to society.
+**Overview**: Technical capabilities alone don't determine AI's impact on society—policy, governance, and ethical considerations are equally critical. This area steps back to examine the bigger picture: how should AI systems be regulated, what are the existential and near-term risks, how do we ensure equitable access and prevent misuse, and what frameworks exist for responsible AI development? Whether you're building AI systems, advising organizations, or simply want to be an informed citizen, understanding these policy and safety considerations is essential as AI becomes increasingly central to society.
 
 ---
 
-## 13.1 Financial Services & Model Risk Management
+## Financial Services & Model Risk Management
 **Goal**: Understand regulatory frameworks for AI in financial services
 
 **Why this matters**: Financial institutions were among the first to systematically regulate AI/ML models. The frameworks developed here—particularly around model validation, governance, and risk management—have influenced AI regulation across industries.
@@ -32,7 +32,7 @@
 
 ---
 
-## 13.2 Data Protection & Privacy Law
+## Data Protection & Privacy Law
 **Goal**: Navigate privacy regulations affecting AI systems
 
 **Why this matters**: AI systems are data-hungry, but data collection and use are heavily regulated. Understanding GDPR, CCPA, and related frameworks is essential for legal AI deployment, especially for systems processing personal data.
@@ -57,7 +57,7 @@
 
 ---
 
-## 13.3 AI-Specific Legislation & Executive Action
+## AI-Specific Legislation & Executive Action
 **Goal**: Understand emerging AI-specific regulatory frameworks
 
 **Why this matters**: Unlike sector-specific rules, these frameworks regulate AI systems directly based on risk, use case, or capability level. They represent the future of AI governance.
@@ -110,7 +110,7 @@
 
 ---
 
-## 13.4 Risk Management Frameworks & Standards
+## Risk Management Frameworks & Standards
 **Goal**: Learn structured approaches to AI risk management
 
 **Why this matters**: Regulations tell you what to do; frameworks tell you how. These voluntary standards provide practical implementation guidance and are increasingly referenced by regulators.
@@ -148,7 +148,7 @@
 
 ---
 
-## 13.5 Sector-Specific AI Guidance
+## Sector-Specific AI Guidance
 **Goal**: Navigate industry-specific AI regulations
 
 **Why this matters**: Healthcare AI faces different requirements than financial AI. Understanding sector-specific rules is essential for practical deployment.
@@ -187,7 +187,7 @@
 
 ---
 
-## 13.6 Dual-Use AI & National Security
+## Dual-Use AI & National Security
 **Goal**: Understand national security considerations for AI
 
 **Why this matters**: Advanced AI models have both beneficial and harmful uses. Export controls, dual-use regulations, and open vs. closed debates shape what can be built and shared.
@@ -211,7 +211,7 @@
 
 ---
 
-## 13.7 Responsible AI & Industry Best Practices
+## Responsible AI & Industry Best Practices
 **Goal**: Understand voluntary frameworks and industry initiatives
 
 **Why this matters**: Many organizations operate ahead of regulation. These frameworks represent current best practices and often foreshadow future requirements.
@@ -248,7 +248,7 @@
 
 ---
 
-## 13.8 Practical Compliance & Implementation
+## Practical Compliance & Implementation
 **Goal**: Apply policy frameworks in real-world scenarios
 
 **Resources for Practitioners**:

--- a/learning/probabilistic.md
+++ b/learning/probabilistic.md
@@ -1,10 +1,10 @@
-# Phase 10: Probabilistic & Bayesian Approaches
+# Probabilistic & Bayesian Approaches
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Advanced Topics](phase-09-advanced.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Advanced](advanced.md) | [Vision](vision.md)
 
-**Phase Overview**: Beyond language models lies a rich world of probabilistic generative models. This phase covers [diffusion models](glossary.md#diffusion-model)—the technology behind Stable Diffusion and DALL-E—which generate high-quality images by gradually denoising random noise. You'll understand the theoretical foundations connecting diffusion to score matching and stochastic differential equations, and how these models have revolutionized image generation, video synthesis, and even molecular design. While briefer than other phases, these concepts are essential for understanding modern generative AI beyond just text.
+**Overview**: Beyond language models lies a rich world of probabilistic generative models. This phase covers [diffusion models](glossary.md#diffusion-model)—the technology behind Stable Diffusion and DALL-E—which generate high-quality images by gradually denoising random noise. You'll understand the theoretical foundations connecting diffusion to score matching and stochastic differential equations, and how these models have revolutionized image generation, video synthesis, and even molecular design. While briefer than other phases, these concepts are essential for understanding modern generative AI beyond just text.
 
-## 10.1 Probabilistic Programming
+## Probabilistic Programming
 **Goal**: Build probabilistic models programmatically
 
 1. [A Probabilistic Programming Approach to Probabilistic Data Analysis](https://papers.nips.cc/paper/6060-a-probabilistic-programming-approach-to-probabilistic-data-analysis.pdf) (2016)
@@ -25,13 +25,13 @@
 6. [MCMC using Hamiltonian dynamics](https://arxiv.org/abs/1206.1901) (2012)
    - *Why*: Foundation of modern MCMC sampling methods
 
-## 10.2 Diffusion Models
+## Diffusion Models
 **Goal**: Understand how diffusion models learn and generalize
 
 1. [Why Diffusion Models Don't Memorize: The Role of Implicit Dynamical Regularization in Training](https://arxiv.org/pdf/2505.17638) (2025)
    - *Why*: Theoretical analysis of why diffusion models generalize rather than memorize training data; identifies two distinct training timescales and implicit dynamical regularization
 
-## 10.3 Generative Models for Vision
+## Generative Models for Vision
 **Goal**: Apply probabilistic models to visual understanding
 
 1. [Approximate Bayesian Image Interpretation using Generative Probabilistic Graphics Programs](http://papers.nips.cc/paper/4881-approximate-bayesian-image-interpretation-using-generative-probabilistic-graphics-programs.pdf) (2013)
@@ -43,4 +43,4 @@
 
 ---
 
-**Next**: [Phase 11: Computer Vision (Optional) →](phase-11-vision.md)
+**Related**: [Advanced](advanced.md) | [Vision](vision.md) | [Hardware](hardware.md)

--- a/learning/reasoning.md
+++ b/learning/reasoning.md
@@ -1,10 +1,10 @@
-# Phase 5: Reasoning & Alignment
+# Reasoning & Alignment
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 4](phase-04-retrieval.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Retrieval](retrieval.md) | [Architectures](architectures.md) | [Safety](safety.md)
 
-**Phase Overview**: Raw language models don't naturally follow instructions or break down complex problems step-by-step. This phase covers the crucial techniques that transform base models into helpful, harmless assistants: [reinforcement learning from human feedback (RLHF)](glossary.md#rlhf-reinforcement-learning-from-human-feedback) that aligns models with human preferences, [chain-of-thought prompting](glossary.md#chain-of-thought-prompting) that enables multi-step reasoning, and [constitutional AI](glossary.md#constitutional-ai) approaches that encode ethical principles. You'll also learn about [agent](glossary.md#agent) frameworks like [ReAct](glossary.md#react-reasoning-and-acting) that give models the ability to use tools and take actions. These methods are what make modern AI systems genuinely useful and (relatively) safe.
+**Overview**: Raw language models don't naturally follow instructions or break down complex problems step-by-step. This phase covers the crucial techniques that transform base models into helpful, harmless assistants: [reinforcement learning from human feedback (RLHF)](glossary.md#rlhf-reinforcement-learning-from-human-feedback) that aligns models with human preferences, [chain-of-thought prompting](glossary.md#chain-of-thought-prompting) that enables multi-step reasoning, and [constitutional AI](glossary.md#constitutional-ai) approaches that encode ethical principles. You'll also learn about [agent](glossary.md#agent) frameworks like [ReAct](glossary.md#react-reasoning-and-acting) that give models the ability to use tools and take actions. These methods are what make modern AI systems genuinely useful and (relatively) safe.
 
-## 5.1 Teaching Models to Reason
+## Teaching Models to Reason
 **Goal**: Build models that can reason and solve complex problems
 
 1. [Deep Reinforcement Learning from Human Preferences](https://arxiv.org/abs/1706.03741) (Christiano et al., 2017)
@@ -31,7 +31,7 @@
 8. [A Simple Neural Network Module for Relational Reasoning](https://arxiv.org/abs/1706.01427) (Santoro et al., 2017)
    - *Why*: **Relational reasoning foundation** - introduces Relation Networks for learning to reason about relationships between objects; essential for visual question answering and abstract reasoning tasks
 
-## 5.2 Agentic Systems
+## Agentic Systems
 **Goal**: Create autonomous AI agents
 
 1. [A Generalist Agent](https://arxiv.org/pdf/2205.06175) (2022)
@@ -57,4 +57,4 @@
 
 ---
 
-**Next**: [Phase 6: Novel Architectures & Theory →](phase-06-architectures.md)
+**Related**: [Retrieval](retrieval.md) | [Architectures](architectures.md) | [Safety](safety.md)

--- a/learning/retrieval.md
+++ b/learning/retrieval.md
@@ -1,10 +1,10 @@
-# Phase 4: Retrieval & Knowledge Systems
+# Retrieval & Knowledge Systems
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Attention](phase-03-attention.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Attention](attention.md) | [Reasoning](reasoning.md)
 
-**Phase Overview**: Language models have limited memory and can [hallucinate](glossary.md#hallucination) facts, but what if they could look up information before answering? This phase introduces [retrieval-augmented generation (RAG)](glossary.md#rag-retrieval-augmented-generation), where models query external knowledge bases to ground their responses in factual sources. You'll learn about dense retrieval systems that find relevant documents, nearest-neighbor approaches that augment model capabilities, and the architectural patterns that make RAG practical. These techniques are essential for building reliable, factual AI systems and are widely used in production applications today.
+**Overview**: Language models have limited memory and can [hallucinate](glossary.md#hallucination) facts, but what if they could look up information before answering? This phase introduces [retrieval-augmented generation (RAG)](glossary.md#rag-retrieval-augmented-generation), where models query external knowledge bases to ground their responses in factual sources. You'll learn about dense retrieval systems that find relevant documents, nearest-neighbor approaches that augment model capabilities, and the architectural patterns that make RAG practical. These techniques are essential for building reliable, factual AI systems and are widely used in production applications today.
 
-## 4.1 Retrieval-Augmented Generation (RAG)
+## Retrieval-Augmented Generation (RAG)
 **Goal**: Combine retrieval with generation for better knowledge access
 
 1. [Dense Passage Retrieval for Open-Domain Question Answering](https://arxiv.org/abs/2004.04906) (Karpukhin et al., 2020)
@@ -31,7 +31,7 @@
 8. [Lost in the Middle: How Language Models Use Long Contexts](https://arxiv.org/abs/2307.03172) (Liu et al., 2023)
    - *Why*: **Critical analysis of long-context usage** - reveals U-shaped performance curve where models struggle with information in the middle of long contexts; important for RAG system design
 
-## 4.2 Federated & Distributed Learning
+## Federated & Distributed Learning
 **Goal**: Train models across distributed data
 
 1. [Federated Learning with Ad-hoc Adapter Insertions: The Case of Soft-Embeddings for Training Classifier-as-Retriever](https://arxiv.org/pdf/2509.16508) (2025)
@@ -39,4 +39,4 @@
 
 ---
 
-**Next**: [Phase 5: AI Reasoning & Agents →](phase-05-reasoning.md)
+**Related**: [Attention](attention.md) | [Reasoning](reasoning.md) | [Language Models](language-models.md)

--- a/learning/safety.md
+++ b/learning/safety.md
@@ -1,8 +1,8 @@
-# Phase 8: Security, Safety & Robustness
+# Security, Safety & Robustness
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 7](phase-07-interpretability.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Interpretability](interpretability.md) | [Reasoning](reasoning.md) | [Policy](policy.md)
 
-**Phase Overview**: AI systems face unique challenges in both **security** and **safety** that don't exist in traditional software. This phase examines both dimensions:
+**Overview**: AI systems face unique challenges in both **security** and **safety** that don't exist in traditional software. This phase examines both dimensions:
 
 **Security** focuses on protecting systems from attacks: [adversarial examples](glossary.md#adversarial-example) that fool models with imperceptible perturbations, [jailbreaking](glossary.md#jailbreaking) techniques that bypass safety guardrails, [prompt injection](glossary.md#prompt-injection) attacks that hijack model behavior, and [data poisoning](glossary.md#data-poisoning) that corrupts training.
 
@@ -10,7 +10,7 @@
 
 As AI systems control increasingly important decisions—from content moderation to autonomous vehicles—understanding both their vulnerabilities and how to ensure safe behavior becomes critical for responsible deployment.
 
-## 8.1 AI Alignment & Safety Training
+## AI Alignment & Safety Training
 **Goal**: Build AI systems that are aligned with human values and safe to deploy
 
 1. [Concrete Problems in AI Safety](https://arxiv.org/abs/1606.06565) (Amodei et al., 2016)
@@ -28,7 +28,7 @@ As AI systems control increasingly important decisions—from content moderation
 5. [Llama Guard: LLM-based Input-Output Safeguard for Human-AI Conversations](https://arxiv.org/abs/2312.06674) (Inan et al., 2023)
    - *Why*: **Practical safety guardrail** - open-source safety classifier for LLM inputs and outputs; defines taxonomy of unsafe content categories; enables deployment of safety-filtered LLM applications
 
-## 8.2 Security Threats & Attacks
+## Security Threats & Attacks
 **Goal**: Understand and defend against security vulnerabilities in AI systems
 
 1. [Pr$εε$mpt: Sanitizing Sensitive Prompts for LLMs](https://arxiv.org/abs/2504.05147) (2025)
@@ -49,7 +49,7 @@ As AI systems control increasingly important decisions—from content moderation
 6. [SEC-bench: Automated Benchmarking of LLM Agents on Real-World Software Security Tasks](https://openreview.net/pdf?id=QQhQIqons0) (Lee et al., 2025)
    - *Why*: First fully automated benchmarking framework for evaluating LLM agents on authentic security engineering tasks; introduces multi-agent scaffold for constructing verified vulnerability datasets with reproducible PoCs and patches; reveals significant performance gaps (18% PoC generation, 34% vulnerability patching)
 
-## 8.3 Safety Evaluation & Red Teaming
+## Safety Evaluation & Red Teaming
 **Goal**: Systematically evaluate AI systems for safety risks and harmful behaviors
 
 1. [Red Teaming Language Models to Reduce Harms: Methods, Scaling Behaviors, and Lessons Learned](https://arxiv.org/abs/2209.07858) (Ganguli et al., 2022)
@@ -66,12 +66,12 @@ As AI systems control increasingly important decisions—from content moderation
 
 5. [TruthfulQA: Measuring How Models Mimic Human Falsehoods](https://arxiv.org/abs/2109.07958) (Lin et al., 2022)
    - *Why*: **Foundational safety benchmark** - reveals that larger models can be less truthful; critical for understanding model limitations and safety risks; measures tendency to generate false but plausible-sounding answers
-   - *Note*: Also covered in Phase 7 for interpretability
+   - *Note*: Also covered in [Interpretability](interpretability.md)
 
 6. [The WMDP Benchmark: Measuring and Reducing Malicious Use With Unlearning](https://arxiv.org/abs/2403.03218) (Li et al., 2024)
    - *Why*: **Weapons of Mass Destruction Proxy benchmark** - evaluates dangerous knowledge in biosecurity, cybersecurity, and chemical security; demonstrates unlearning can reduce hazardous capabilities while maintaining general performance; critical for preventing dual-use risks
 
-## 8.4 Bias, Fairness & Robustness
+## Bias, Fairness & Robustness
 **Goal**: Detect, measure, and mitigate bias in AI systems while maintaining robustness
 
 1. [Equality of Opportunity in Supervised Learning](https://arxiv.org/abs/1610.02413) (Hardt et al., 2016)
@@ -85,9 +85,9 @@ As AI systems control increasingly important decisions—from content moderation
 
 4. [On Calibration of Modern Neural Networks](https://arxiv.org/abs/1706.04599) (Guo et al., 2017)
    - *Why*: **Foundational work on model calibration** - shows modern neural networks are poorly calibrated despite high accuracy; important for understanding when to trust model predictions; critical for safety-critical applications
-   - *Note*: Also relevant for interpretability (Phase 7)
+   - *Note*: Also relevant for [Interpretability](interpretability.md)
 
-## 8.5 Harmful Content & Misinformation
+## Harmful Content & Misinformation
 **Goal**: Detect and mitigate harmful content generation and misinformation
 
 1. [RealToxicityPrompts: Evaluating Neural Toxic Degeneration in Language Models](https://arxiv.org/abs/2009.11462) (Gehman et al., 2020)
@@ -104,7 +104,7 @@ As AI systems control increasingly important decisions—from content moderation
    - *Why*: Benchmark measuring how models generate misinformation by mimicking human falsehoods; reveals counterintuitive scaling where larger models can be less truthful
    - *Note*: Also listed in 8.3 for safety evaluation context
 
-## 8.6 Long-term Safety Research
+## Long-term Safety Research
 **Goal**: Understand and address long-term safety challenges for advanced AI systems
 
 1. [Concrete Problems in AI Safety](https://arxiv.org/abs/1606.06565) (Amodei et al., 2016)
@@ -123,7 +123,7 @@ As AI systems control increasingly important decisions—from content moderation
 
 5. [Interpretability in the Wild: a Circuit for Indirect Object Identification in GPT-2 small](https://transformer-circuits.pub/2022/in-context-learning-and-induction-heads/index.html) (Elhage et al., 2022)
    - *Why*: **Mechanistic interpretability for safety** - demonstrates how to reverse-engineer model behavior to understand what models are actually doing; essential for detecting deceptive or misaligned behavior
-   - *Note*: Part of Anthropic's interpretability research; also relevant for Phase 7
+   - *Note*: Part of Anthropic's interpretability research; also relevant for [Interpretability](interpretability.md)
 
 6. [Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems](https://arxiv.org/abs/2405.06624) (Dalrymple et al., 2024)
    - *Why*: Proposes world model-based safety framework with quantitative guarantees; addresses how to build AI systems with provable safety properties; important for high-stakes deployment scenarios
@@ -133,4 +133,4 @@ As AI systems control increasingly important decisions—from content moderation
 
 ---
 
-**Next**: [Phase 9: Advanced Topics & Frontiers →](phase-09-advanced.md)
+**Related**: [Interpretability](interpretability.md) | [Advanced](advanced.md) | [Policy](policy.md)

--- a/learning/vision.md
+++ b/learning/vision.md
@@ -1,10 +1,10 @@
-# Phase 11: Vision & Multimodal Systems
+# Vision & Multimodal Systems
 
-[← Back to Learning Path](../learning-path.md) | [← Previous: Phase 10](phase-10-probabilistic.md) | [📖 Glossary](glossary.md)
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Probabilistic](probabilistic.md) | [Hardware](hardware.md)
 
-**Phase Overview**: The transformer revolution didn't stop at text—it transformed computer vision too. This phase explores how [attention mechanisms](glossary.md#attention-mechanism) replaced [convolutional neural networks](glossary.md#cnn-convolutional-neural-network) as the dominant paradigm in vision, how [CLIP](glossary.md#clip-contrastive-language-image-pre-training) bridges vision and language through contrastive learning, and how models like [SAM](glossary.md#sam-segment-anything-model) achieve unprecedented zero-shot image segmentation. You'll see how the same principles that power ChatGPT enable models to understand and generate images, paving the way for truly [multimodal](glossary.md#multimodal-learning) AI systems that can seamlessly work with text, images, and video together.
+**Overview**: The transformer revolution didn't stop at text—it transformed computer vision too. This phase explores how [attention mechanisms](glossary.md#attention-mechanism) replaced [convolutional neural networks](glossary.md#cnn-convolutional-neural-network) as the dominant paradigm in vision, how [CLIP](glossary.md#clip-contrastive-language-image-pre-training) bridges vision and language through contrastive learning, and how models like [SAM](glossary.md#sam-segment-anything-model) achieve unprecedented zero-shot image segmentation. You'll see how the same principles that power ChatGPT enable models to understand and generate images, paving the way for truly [multimodal](glossary.md#multimodal-learning) AI systems that can seamlessly work with text, images, and video together.
 
-## 11.1 Vision Transformers
+## Vision Transformers
 
 1. [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale (Vision Transformer/ViT)](https://arxiv.org/abs/2010.11929) (Dosovitskiy et al., 2021)
    - *Why*: **Missing but crucial** - applies pure transformers to vision; connects vision and language model architectures
@@ -24,7 +24,7 @@
 6. [Semantic Segmentation using Adversarial Networks](https://arxiv.org/abs/1611.08408) (2016)
    - *Why*: Applying GANs to segmentation tasks
 
-## 11.2 Multimodal & Speech
+## Multimodal & Speech
 
 1. [Visual Instruction Tuning (LLaVA)](https://arxiv.org/abs/2304.08485) (Liu et al., 2023)
    - *Why*: **Pioneering vision-language instruction following** - connects vision encoder with LLM for multimodal conversations; demonstrates that instruction tuning works across modalities; foundation for many open-source multimodal models
@@ -32,7 +32,7 @@
 2. [Deep Speech 2: End-to-End Speech Recognition in English and Mandarin](https://arxiv.org/abs/1512.02595) (Amodei et al., 2016)
    - *Why*: **End-to-end speech recognition** - demonstrates deep learning for speech without hand-engineered features; scales to multiple languages; foundational for modern speech systems
 
-## 11.3 Vision Interpretability
+## Vision Interpretability
 
 1. [Deep Inside Convolutional Networks: Visualising Image Classification Models and Saliency Maps](https://arxiv.org/abs/1312.6034) (2013)
    - *Why*: Visualizing image classification models
@@ -45,4 +45,4 @@
 
 ---
 
-**Next**: [Phase 12: Hardware & Systems →](phase-12-hardware.md)
+**Related**: [Probabilistic](probabilistic.md) | [Hardware](hardware.md) | [Interpretability](interpretability.md)


### PR DESCRIPTION
## Summary
- **Restructure**: Replaced 13 numbered phases with topic-based **areas** and **tracks** (curated reading sequences). Areas have no implied order; tracks suggest an order for different goals (Comprehensive, ML Practitioner, Researcher, Engineer, Security Specialist).
- **Renames**: `phase-01-foundations.md` → `foundations.md`, etc. All cross-links, nav, and section headers updated.
- **Docs**: learning-path.md, README, CONTRIBUTING, and GitHub issue/PR templates updated (phase → area).
- **New paper**: [H-Neurons (Gao et al., 2025)](https://arxiv.org/abs/2512.01797) added to Interpretability area, by-date.md, and glossary.

## Checklist
- [x] All phase files renamed to area names
- [x] Area content updated (titles, Related nav, section headers)
- [x] learning-path.md converted to areas + tracks
- [x] README, CONTRIBUTING, templates updated
- [x] H-Neurons paper and glossary term added

Made with [Cursor](https://cursor.com)