### PR TITLE
Add Agents of Chaos paper + update add-paper command for branch protection

### DIFF
--- a/.cursor/commands/add-paper.md
+++ b/.cursor/commands/add-paper.md
@@ -51,8 +51,14 @@ Edit `by-date.md`:
 - Insert a new bullet at the top of that month's list: `- [Full Paper Title](canonical_url) (Authors, Year)`.
 - Keep months in reverse chronological order (newest first). Create a new year section at the top of the file if the paper is from a future year.
 
-### 6. Commit
-Commit the two changed files with a clear message, e.g. `Add paper: Title (YYYY)`.
+### 6. Branch, commit, PR, and merge
+Do not commit directly to `main`. Instead:
+
+1. Create a new branch from `main` named `add-<short-kebab-title>` (e.g. `add-agents-of-chaos`).
+2. Commit the two changed files with a clear message, e.g. `Add paper: Title (YYYY)`.
+3. Push the branch and create a pull request into `main` using `gh pr create`.
+4. Merge the PR using `gh pr merge --merge`.
+5. Switch back to `main` and pull to sync.
 
 ## Conventions (from CONTRIBUTING.md)
 - Use `###` for paper titles only where CONTRIBUTING specifies; in topic files use numbered list entries.

--- a/by-date.md
+++ b/by-date.md
@@ -3,6 +3,7 @@
 ## 2026
 
 ### 2026.02
+- [Agents of Chaos](https://arxiv.org/abs/2602.20021) (Shapira et al., 2026)
 - [Do LLMs Benefit From Their Own Words?](https://arxiv.org/abs/2602.24287) (Huang et al., 2026)
 
 ## 2025

--- a/learning/safety.md
+++ b/learning/safety.md
@@ -71,6 +71,9 @@ As AI systems control increasingly important decisions—from content moderation
 6. [The WMDP Benchmark: Measuring and Reducing Malicious Use With Unlearning](https://arxiv.org/abs/2403.03218) (Li et al., 2024)
    - *Why*: **Weapons of Mass Destruction Proxy benchmark** - evaluates dangerous knowledge in biosecurity, cybersecurity, and chemical security; demonstrates unlearning can reduce hazardous capabilities while maintaining general performance; critical for preventing dual-use risks
 
+7. [Agents of Chaos](https://arxiv.org/abs/2602.20021) (Shapira et al., 2026)
+   - *Why*: Empirical red-teaming of autonomous LLM agents with persistent memory, email, shell access, and multi-agent communication in a live environment; documents eleven failure modes including unauthorized compliance, identity spoofing, cross-agent propagation, and partial system takeover
+
 ## Bias, Fairness & Robustness
 **Goal**: Detect, measure, and mitigate bias in AI systems while maintaining robustness
 


### PR DESCRIPTION
## Summary
- Adds paper: **Agents of Chaos** (Shapira et al., 2026) to `learning/safety.md` (Safety Evaluation & Red Teaming) and `by-date.md` (2026.02)
- Updates `.cursor/commands/add-paper.md` to require a branch + PR + merge workflow instead of committing directly to main

Made with [Cursor](https://cursor.com)