### PR TITLE
Add Human-AI Interaction & Cognition learning area

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,7 @@ Consider which topic area the paper belongs to:
 | Probabilistic | Probabilistic models | Diffusion, Bayesian methods |
 | Vision | Vision & multimodal | ViT, CLIP, SAM |
 | Hardware | Hardware & systems | Photonics, VLSI |
+| Human-AI Interaction | Human cognition with AI | Cognitive surrender, automation bias |
 | Policy | Policy & governance | GDPR, EU AI Act, NIST RMF |
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 > A curated, pedagogically-organized collection of essential research papers spanning the landscape of modern artificial intelligence and machine learning.
 
-[![Papers](https://img.shields.io/badge/papers-150+-blue.svg)](by-date.md)
-[![Learning Path](https://img.shields.io/badge/learning-13_areas-green.svg)](learning-path.md)
+[![Papers](https://img.shields.io/badge/papers-160+-blue.svg)](by-date.md)
+[![Learning Path](https://img.shields.io/badge/learning-14_areas-green.svg)](learning-path.md)
 [![Glossary](https://img.shields.io/badge/glossary-250+_terms-purple.svg)](learning/glossary.md)
 
 ---
 
 ## 🎯 What's Inside
 
-This repository contains **150+ carefully selected research papers** organized in three complementary ways:
+This repository contains **160+ carefully selected research papers** organized in three complementary ways:
 
 1. **📚 [Structured Learning Path](learning-path.md)** - Topic areas and curated tracks from foundations to cutting-edge research
 2. **📅 [Chronological Timeline](by-date.md)** - Papers organized by publication date (1997-2025)
@@ -87,7 +87,7 @@ Browse the **[Chronological View](by-date.md)** to see latest 2025 research, or 
 
 ## 📖 Learning Path Overview
 
-The learning path is organized into **13 topic areas**; use [learning-path.md](learning-path.md) for curated **tracks** (reading sequences by goal).
+The learning path is organized into **14 topic areas**; use [learning-path.md](learning-path.md) for curated **tracks** (reading sequences by goal).
 
 | Area | Topic | Papers | Focus |
 |------|-------|--------|-------|
@@ -103,9 +103,10 @@ The learning path is organized into **13 topic areas**; use [learning-path.md](l
 | **[Probabilistic](learning/probabilistic.md)** | 🎲 **Probabilistic Models** | 6 | Diffusion, probabilistic programming |
 | **[Vision](learning/vision.md)** | 👁️ **Vision & Multimodal** | 10 | ViT, CLIP, SAM, LLaVA, vision-language models |
 | **[Hardware](learning/hardware.md)** | ⚙️ **Hardware & Systems** | 4 | GPU optimization, inference scaling, photonic computing |
+| **[Human-AI Interaction](learning/human-ai-interaction.md)** | 🧠 **Human-AI Interaction** | 11 | Trust, automation bias, cognitive effects, human-AI teams |
 | **[Policy](learning/policy.md)** | 📜 **Policy & Governance** | 40+ | GDPR, EU AI Act, NIST AI RMF, OCC model risk guidance |
 
-**Total**: 150+ core papers across 13 areas (plus 40+ policy documents & frameworks)
+**Total**: 160+ core papers across 14 areas (plus 40+ policy documents & frameworks)
 
 ---
 
@@ -178,6 +179,11 @@ This collection spans the full spectrum of modern AI/ML research, organized by t
 - Interpretability: [DeconvNet](https://arxiv.org/abs/1311.2901), [saliency maps](https://arxiv.org/abs/1312.6034), visualization techniques
 - Segmentation: [All-CNN](https://arxiv.org/abs/1412.6806), [adversarial segmentation](https://arxiv.org/abs/1611.08408)
 - Multimodal understanding: Vision-language models
+
+### 🧠 Human-AI Interaction & Cognition
+- **Trust & Reliance**: [Thinking, Fast and Slow](https://us.macmillan.com/books/9780374533557/thinkingfastandslow) (dual-process theory), [automation bias](https://journals.sagepub.com/doi/10.1518/001872097778543886), [trust in automation](https://journals.sagepub.com/doi/10.1518/hfes.46.1.50_30392), [algorithm aversion](https://psycnet.apa.org/record/2014-48748-001)
+- **Cognitive Effects**: [Extended mind](https://academic.oup.com/analysis/article-abstract/58/1/7/153111), [cognitive offloading](https://www.cell.com/trends/cognitive-sciences/abstract/S1364-6613(16)30098-5), [cognitive surrender](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6097646), [cognitive debt](https://arxiv.org/abs/2506.08872)
+- **Decision-Making**: [Algorithm-in-the-loop](https://dl.acm.org/doi/10.1145/3359152), [AI explanations & team performance](https://arxiv.org/abs/2006.14779), [cognitive forcing functions](https://arxiv.org/abs/2102.09692)
 
 ### 🎯 Advanced Applications
 - **Scientific AI**: [AI scientist](https://arxiv.org/pdf/2408.06292), [scientific software generation](https://arxiv.org/pdf/2509.06503), [architecture discovery](https://arxiv.org/pdf/2507.18074)

--- a/by-date.md
+++ b/by-date.md
@@ -9,6 +9,9 @@
 - [Agents of Chaos](https://arxiv.org/abs/2602.20021) (Shapira et al., 2026)
 - [Do LLMs Benefit From Their Own Words?](https://arxiv.org/abs/2602.24287) (Huang et al., 2026)
 
+### 2026.01
+- [Thinking—Fast, Slow, and Artificial: How AI is Reshaping Human Reasoning and the Rise of Cognitive Surrender](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6097646) (Shaw & Nave, 2026)
+
 ## 2025
 
 ### 2025.12
@@ -47,6 +50,7 @@
 
 ### 2025.06
 - [Artificial Intelligent Disobedience: Rethinking the Agency of Our Artificial Teammates](https://arxiv.org/abs/2506.22276) (Mirsky, 2025)
+- [Your Brain on ChatGPT: Accumulation of Cognitive Debt when Using an AI Assistant for Essay Writing Task](https://arxiv.org/abs/2506.08872) (Kosmyna et al., 2025)
 - [Hierarchical Reasoning Model](https://arxiv.org/pdf/2506.21734)
 - [Small Language Models are the Future of Agentic AI](https://arxiv.org/abs/2506.02153)
 - [Reinforcement Pre-Training](https://arxiv.org/abs/2506.08007)
@@ -185,6 +189,9 @@
 
 ## 2021
 
+### 2021.05
+- [Does the Whole Exceed its Parts? The Effect of AI Explanations on Complementary Team Performance](https://arxiv.org/abs/2006.14779) (Bansal et al., 2021)
+
 ### 2021.04
 - [Efficient Large-Scale Language Model Training on GPU Clusters Using Megatron-LM](https://arxiv.org/abs/2104.04473)
 
@@ -192,6 +199,7 @@
 - [Learning Transferable Visual Models From Natural Language Supervision (CLIP)](https://arxiv.org/abs/2103.00020)
 
 ### 2021.02
+- [To Trust or to Think: Cognitive Forcing Functions Can Reduce Overreliance on AI in AI-Assisted Decision-Making](https://arxiv.org/abs/2102.09692) (Buçinca et al., 2021)
 - [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale (Vision Transformer/ViT)](https://arxiv.org/abs/2010.11929)
 
 ### 2021.01
@@ -221,6 +229,7 @@
 ## 2019
 
 ### 2019.11
+- [The Principles and Limits of Algorithm-in-the-Loop Decision Making](https://dl.acm.org/doi/10.1145/3359152) (Green & Chen, 2019)
 - [Generalization through Memorization: Nearest Neighbor Language Models (kNN-LM)](https://arxiv.org/abs/1911.00172)
 
 ### 2019.10
@@ -291,6 +300,9 @@
 ### 2016.10
 - [Equality of Opportunity in Supervised Learning](https://arxiv.org/abs/1610.02413)
 
+### 2016.09
+- 🔒 [Cognitive Offloading](https://www.cell.com/trends/cognitive-sciences/abstract/S1364-6613(16)30098-5) (Risko & Gilbert, 2016) - *Paywalled*
+
 ### 2016.06
 - [Learning Convolutional Neural Networks for Graphs](http://proceedings.mlr.press/v48/niepert16.pdf)
 - [Synthesizing the Preferred Inputs for Neurons via Deep Generator Networks](https://arxiv.org/abs/1605.09304)
@@ -320,6 +332,9 @@
 
 ### 2015.05
 - [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
+
+### 2015.02
+- 🔒 [Algorithm Aversion: People Erroneously Avoid Algorithms After Seeing Them Err](https://psycnet.apa.org/record/2014-48748-001) (Dietvorst et al., 2015) - *Paywalled*
 
 ### 2015-CVPR
 - [Picture: An Imperative Probabilistic Programming Language for Scene Perception](https://openaccess.thecvf.com/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf)
@@ -357,6 +372,10 @@
 - [ImageNet Classification with Deep Convolutional Neural Networks (AlexNet)](https://papers.nips.cc/paper_files/paper/2012/file/c399862d3b9d6b76c8436e924a68c45b-Paper.pdf)
 - [MCMC using Hamiltonian dynamics](https://arxiv.org/abs/1206.1901)
 
+## 2011
+
+- [Thinking, Fast and Slow](https://us.macmillan.com/books/9780374533557/thinkingfastandslow) (Kahneman, 2011)
+
 ## 2010
 
 - [Understanding the Difficulty of Training Deep Feedforward Neural Networks](https://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf)
@@ -366,15 +385,21 @@
 
 - 🔒 [A Bayesian Framework for Modeling Intuitive Dynamics](https://cocosci.berkeley.edu/tom/papers/collisions.pdf) - *May require institutional access*
 
+## 2004
+
+- 🔒 [Trust in Automation: Designing for Appropriate Reliance](https://journals.sagepub.com/doi/10.1518/hfes.46.1.50_30392) (Lee & See, 2004) - *Paywalled*
+
 ## 1997-2001
 
+- 🔒 [The Extended Mind](https://academic.oup.com/analysis/article-abstract/58/1/7/153111) (Clark & Chalmers, 1998) - *Paywalled*
+- 🔒 [Humans and Automation: Use, Misuse, Disuse, Abuse](https://journals.sagepub.com/doi/10.1518/001872097778543886) (Parasuraman & Riley, 1997) - *Paywalled*
 - 🔒 [Long Short-Term Memory (LSTM)](https://www.researchgate.net/publication/13853244_Long_Short-term_Memory) (1997) - *Paywalled*
 - [Gradient-Based Learning Applied to Document Recognition (LeNet)](http://yann.lecun.com/exdb/publis/pdf/lecun-01a.pdf) (1998)
 
 ---
 
-**Total Papers in Learning Path**: 150+ papers
-**Paywalled Papers**: 4 (marked with 🔒)  
-**Open Access**: ~97%
+**Total Papers in Learning Path**: 160+ papers
+**Paywalled Papers**: 11 (marked with 🔒)
+**Open Access**: ~93%
 
 [← Back to Main](README.md) | [→ View Learning Path](learning-path.md)

--- a/learning-path.md
+++ b/learning-path.md
@@ -77,6 +77,11 @@ You can **follow a track** for a guided path, **jump to specific areas** based o
   - Hardware-Algorithm Co-design
   - Specialized AI Hardware
 
+- **[Human-AI Interaction & Cognition](learning/human-ai-interaction.md)**
+  - Trust, Reliance & Automation Bias
+  - Cognitive Effects of AI
+  - Human-AI Decision-Making
+
 - **[Policy, Safety & Societal Impact](learning/policy.md)**
   - Financial Services & Model Risk Management (OCC 2011-12, SR 11-7)
   - Data Protection & Privacy Law (GDPR, CCPA)
@@ -94,7 +99,7 @@ You can **follow a track** for a guided path, **jump to specific areas** based o
 Tracks suggest an order across areas for different goals. Pick one that fits your role or goal, then follow the listed areas in sequence (or skip around as needed).
 
 ### Comprehensive Track
-Full curriculum in a logical order: [Foundations](learning/foundations.md) → [Language Models](learning/language-models.md) → [Attention](learning/attention.md) → [Retrieval](learning/retrieval.md) → [Reasoning](learning/reasoning.md) → [Architectures](learning/architectures.md) → [Interpretability](learning/interpretability.md) → [Safety](learning/safety.md) → [Advanced](learning/advanced.md) → [Probabilistic](learning/probabilistic.md) → [Vision](learning/vision.md) → [Hardware](learning/hardware.md) → [Policy](learning/policy.md).
+Full curriculum in a logical order: [Foundations](learning/foundations.md) → [Language Models](learning/language-models.md) → [Attention](learning/attention.md) → [Retrieval](learning/retrieval.md) → [Reasoning](learning/reasoning.md) → [Architectures](learning/architectures.md) → [Interpretability](learning/interpretability.md) → [Safety](learning/safety.md) → [Advanced](learning/advanced.md) → [Probabilistic](learning/probabilistic.md) → [Vision](learning/vision.md) → [Hardware](learning/hardware.md) → [Human-AI Interaction](learning/human-ai-interaction.md) → [Policy](learning/policy.md).
 
 ### For Beginners
 Start with [Foundations](learning/foundations.md) and [Language Models — LLM Foundations](learning/language-models.md#llm-foundations), then explore based on interests.
@@ -147,4 +152,4 @@ Prioritize [Language Models](learning/language-models.md), [Attention](learning/
 
 ---
 
-*Last updated: March 4, 2026*
+*Last updated: March 23, 2026*

--- a/learning/human-ai-interaction.md
+++ b/learning/human-ai-interaction.md
@@ -1,0 +1,52 @@
+# Human-AI Interaction & Cognition
+
+[← Back to Learning Path](../learning-path.md) | [📖 Glossary](glossary.md) | Related: [Reasoning](reasoning.md) | [Safety](safety.md) | [Policy](policy.md)
+
+**Overview**: AI systems don't just produce outputs—they reshape how humans think, decide, and act. This area examines the human side of the human-AI equation: how people calibrate trust in automated systems, when they over-rely on or reject algorithmic advice, and how sustained AI use may alter cognition itself. Building on decades of research in [automation bias](glossary.md#automation-bias), dual-process theory, and human factors, these papers are essential for anyone designing AI systems that humans actually interact with—or studying what happens when they do.
+
+## Trust, Reliance & Automation Bias
+**Goal**: Understand when and why humans trust, distrust, or blindly follow AI systems
+
+1. [Thinking, Fast and Slow](https://us.macmillan.com/books/9780374533557/thinkingfastandslow) (Kahneman, 2011)
+   - *Why*: Foundational synthesis of dual-process theory (System 1/System 2) underpinning all research on human judgment heuristics and AI over-reliance
+   - *Note*: Book, not a paper; essential background for understanding cognitive surrender and automation bias
+
+2. 🔒 [Humans and Automation: Use, Misuse, Disuse, Abuse](https://journals.sagepub.com/doi/10.1518/001872097778543886) (Parasuraman & Riley, 1997)
+   - *Why*: Seminal framework defining how humans interact with automation—overreliance, underutilization, and misuse; foundational taxonomy still used in modern AI interaction research
+
+3. 🔒 [Trust in Automation: Designing for Appropriate Reliance](https://journals.sagepub.com/doi/10.1518/hfes.46.1.50_30392) (Lee & See, 2004)
+   - *Why*: Introduces the calibrated trust model explaining why people adjust confidence in automated systems; directly applicable to designing AI assistants that foster appropriate (not blind) reliance
+
+4. 🔒 [Algorithm Aversion: People Erroneously Avoid Algorithms After Seeing Them Err](https://psycnet.apa.org/record/2014-48748-001) (Dietvorst et al., 2015)
+   - *Why*: Demonstrates the paradox where people reject statistically superior algorithms after observing single errors while tolerating worse human forecasters; the flip side of automation bias
+
+## Cognitive Effects of AI
+**Goal**: Understand how AI reshapes human thinking, memory, and reasoning
+
+1. 🔒 [The Extended Mind](https://academic.oup.com/analysis/article-abstract/58/1/7/153111) (Clark & Chalmers, 1998)
+   - *Why*: Philosophical foundation arguing that cognition extends beyond the brain into external tools and artifacts; essential grounding for understanding AI as a functional component of human thought
+
+2. 🔒 [Cognitive Offloading](https://www.cell.com/trends/cognitive-sciences/abstract/S1364-6613(16)30098-5) (Risko & Gilbert, 2016)
+   - *Why*: Foundational review of how people use external tools to reduce cognitive demand; distinguishes strategic offloading from the deeper abdication of judgment that AI enables
+
+3. [Your Brain on ChatGPT: Accumulation of Cognitive Debt when Using an AI Assistant for Essay Writing Task](https://arxiv.org/abs/2506.08872) (Kosmyna et al., 2025)
+   - *Why*: Neuroimaging study showing LLM users display weaker brain connectivity than search-engine or traditional learners; introduces "cognitive debt"—short-term cognitive relief creating long-term mental atrophy
+
+4. [Thinking—Fast, Slow, and Artificial: How AI is Reshaping Human Reasoning and the Rise of Cognitive Surrender](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6097646) (Shaw & Nave, 2026)
+   - *Why*: Introduces Tri-System Theory extending dual-process cognition with System 3 (artificial cognition); demonstrates "cognitive surrender"—adopting AI outputs with minimal scrutiny—across three preregistered experiments (N=1,372), showing AI access increases both accuracy and confidence even when the AI errs
+
+## Human-AI Decision-Making
+**Goal**: Learn how human-AI teams actually perform and how to improve collaboration
+
+1. [The Principles and Limits of Algorithm-in-the-Loop Decision Making](https://dl.acm.org/doi/10.1145/3359152) (Green & Chen, 2019)
+   - *Why*: Empirical study showing humans fail to accurately evaluate algorithmic reliability and don't calibrate reliance on system performance; reveals fundamental limits of algorithm-in-the-loop approaches
+
+2. [Does the Whole Exceed its Parts? The Effect of AI Explanations on Complementary Team Performance](https://arxiv.org/abs/2006.14779) (Bansal et al., 2021)
+   - *Why*: Shows AI explanations increase human reliance regardless of correctness without improving complementary team performance; challenges the assumption that transparency alone fixes over-reliance
+
+3. [To Trust or to Think: Cognitive Forcing Functions Can Reduce Overreliance on AI in AI-Assisted Decision-Making](https://arxiv.org/abs/2102.09692) (Buçinca et al., 2021)
+   - *Why*: Demonstrates that cognitive forcing functions (requiring humans to commit to an answer before seeing AI advice) reduce over-reliance, though at cost of user satisfaction; practical intervention design for human-AI systems
+
+---
+
+**Related**: [Reasoning](reasoning.md) | [Safety](safety.md) | [Policy](policy.md)


### PR DESCRIPTION
## Summary
- Creates new `learning/human-ai-interaction.md` topic file with 11 verified papers across three sections: Trust, Reliance & Automation Bias; Cognitive Effects of AI; Human-AI Decision-Making
- Adds Shaw & Nave (2026) "Thinking—Fast, Slow, and Artificial" (Tri-System Theory / cognitive surrender) as the primary new paper
- Seeds the area with foundational works: Kahneman (2011), Parasuraman & Riley (1997), Lee & See (2004), Clark & Chalmers (1998), Dietvorst et al. (2015), Risko & Gilbert (2016), and contemporary papers: Kosmyna et al. (2025), Green & Chen (2019), Bansal et al. (2021), Buçinca et al. (2021)
- Updates `by-date.md`, `learning-path.md`, `README.md`, and `CONTRIBUTING.md` to wire in the 14th learning area

## Test plan
- [ ] Verify all 11 paper URLs resolve correctly
- [ ] Confirm `learning-path.md` Comprehensive Track includes the new area
- [ ] Confirm `README.md` badges show 14 areas / 160+ papers
- [ ] Check `by-date.md` entries are in correct chronological positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)