### PR TITLE
Add paper: LeWorldModel (2026)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -3,6 +3,7 @@
 ## 2026
 
 ### 2026.03
+- [LeWorldModel: Stable End-to-End Joint-Embedding Predictive Architecture from Pixels](https://arxiv.org/abs/2603.19312) (Maes et al., 2026)
 - [Farther the Shift, Sparser the Representation: Analyzing OOD Mechanisms in LLMs](https://arxiv.org/abs/2603.03415) (Jin et al., 2026)
 
 ### 2026.02

--- a/learning/architectures.md
+++ b/learning/architectures.md
@@ -37,6 +37,9 @@
 10. [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880) (Xie et al., 2025)
    - *Why*: **Extends Hyper-Connections with stability guarantees** - projects residual connection space onto a constrained manifold to restore identity mapping property; addresses training instability and scalability issues in HC while maintaining performance gains; demonstrates effectiveness at scale (3B-27B models) with improved stability
 
+11. [LeWorldModel: Stable End-to-End Joint-Embedding Predictive Architecture from Pixels](https://arxiv.org/abs/2603.19312) (Maes et al., 2026)
+   - *Why*: **First stable end-to-end JEPA from raw pixels** - trains a Joint Embedding Predictive Architecture using only a prediction loss and a Gaussian regularizer, eliminating the complex multi-term losses and EMA tricks prior JEPAs required; plans up to 48x faster than foundation-model-based world models on 2D/3D control tasks with ~15M parameters on a single GPU
+
 ## Theoretical Foundations
 **Goal**: Understand the mathematical foundations
 


### PR DESCRIPTION
## Summary
- Add "LeWorldModel: Stable End-to-End Joint-Embedding Predictive Architecture from Pixels" (Maes et al., 2026) to Alternative Architectures in `learning/architectures.md`
- Add to chronological index under 2026.03 in `by-date.md`

## Test plan
- [x] Paper entry follows existing numbered list format
- [x] arXiv abstract URL used
- [x] by-date.md entry at top of 2026.03 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)