### PR TITLE
Add paper: Embarrassingly Simple Self-Distillation Improves Code Generation (2026)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -2,6 +2,9 @@
 
 ## 2026
 
+### 2026.04
+- [Embarrassingly Simple Self-Distillation Improves Code Generation](https://arxiv.org/abs/2604.01193) (Zhang et al., 2026)
+
 ### 2026.03
 - [cuGenOpt: A GPU-Accelerated General-Purpose Metaheuristic Framework for Combinatorial Optimization](https://arxiv.org/abs/2603.19163) (Liu, 2026)
 - [LeWorldModel: Stable End-to-End Joint-Embedding Predictive Architecture from Pixels](https://arxiv.org/abs/2603.19312) (Maes et al., 2026)

--- a/learning/reasoning.md
+++ b/learning/reasoning.md
@@ -31,6 +31,9 @@
 8. [A Simple Neural Network Module for Relational Reasoning](https://arxiv.org/abs/1706.01427) (Santoro et al., 2017)
    - *Why*: **Relational reasoning foundation** - introduces Relation Networks for learning to reason about relationships between objects; essential for visual question answering and abstract reasoning tasks
 
+9. [Embarrassingly Simple Self-Distillation Improves Code Generation](https://arxiv.org/abs/2604.01193) (Zhang et al., 2026)
+   - *Why*: **Self-distillation for code generation** - shows that sampling solutions at a tuned temperature and retraining on them lifts Qwen3-30B-Instruct's LiveCodeBench v6 pass@1 from 42.4% to 55.3%, with the largest gains on hard problems; frames the improvement as resolving a precision-exploration conflict in decoding by suppressing unhelpful token variations while preserving useful exploratory diversity.
+
 ## Agentic Systems
 **Goal**: Create autonomous AI agents
 


### PR DESCRIPTION
## Summary
- Adds Zhang et al. 2026 to `learning/reasoning.md` under "Teaching Models to Reason"
- Adds chronological entry under new `### 2026.04` section in `by-date.md`

## Test plan
- [x] Entry follows existing numbered format with arXiv abstract URL
- [x] Why line is specific and contextual (1-2 sentences)
- [x] New month section created at top of 2026 in `by-date.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)