### PR TITLE
Add paper: MegaTrain (2026)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -3,6 +3,7 @@
 ## 2026
 
 ### 2026.04
+- [MegaTrain: Full Precision Training of 100B+ Parameter Large Language Models on a Single GPU](https://arxiv.org/abs/2604.05091) (Yuan et al., 2026)
 - [Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the LLM Supply Chain](https://arxiv.org/abs/2604.08407) (Liu et al., 2026)
 - [Embarrassingly Simple Self-Distillation Improves Code Generation](https://arxiv.org/abs/2604.01193) (Zhang et al., 2026)
 

--- a/learning/language-models.md
+++ b/learning/language-models.md
@@ -52,6 +52,9 @@
 5. [The Potential of Second-Order Optimization for LLMs: A Study with Full Gauss-Newton](https://arxiv.org/pdf/2510.09378) (2025)
    - *Why*: **Second-order methods revisited for LLMs** - makes full Gauss-Newton optimization tractable at LLM scale through careful implementation; shows curvature-aware updates converge in fewer steps than Adam on language modeling tasks; quantifies the gap between first- and second-order methods to motivate future optimizer research
 
+6. [MegaTrain: Full Precision Training of 100B+ Parameter Large Language Models on a Single GPU](https://arxiv.org/abs/2604.05091) (Yuan et al., 2026)
+   - *Why*: Stores parameters and optimizer states in host memory and treats the GPU as a transient compute engine, using pipelined double-buffered execution across CUDA streams and stateless layer templates in place of a persistent autograd graph; trains up to 120B parameters full precision on a single H200 and achieves 1.84× the throughput of DeepSpeed ZeRO-3 with CPU offloading at 14B.
+
 ## Memory & Efficiency Optimizations
 **Goal**: Make models faster and more memory-efficient
 


### PR DESCRIPTION
## Summary
- Adds MegaTrain (Yuan et al., 2026) to `learning/language-models.md` under **Training at Scale**
- Adds it to the top of `### 2026.04` in `by-date.md`

The paper enables full-precision training of 100B+ parameter LLMs on a single GPU by storing parameters and optimizer states in host memory and using pipelined double-buffered CUDA execution. Direct peer to ZeRO (already in this section); benchmarks against DeepSpeed ZeRO-3.

## Test plan
- [x] Entry follows existing numbered format in Training at Scale
- [x] Chronological index updated with arXiv abstract URL
- [x] No emoji on research paper entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)