### PR TITLE
Add paper: Scaling Latent Reasoning via Looped Language Models (2025)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -34,6 +34,7 @@
 - [Nested Learning: The Illusion of Deep Learning Architectures](https://abehrouz.github.io/files/NL.pdf) - NeurIPS 2025
 
 ### 2025.10
+- [Scaling Latent Reasoning via Looped Language Models](https://arxiv.org/abs/2510.25741) (Zhu et al., 2025)
 - [Breaking Agent Backbones: Evaluating the Security of Backbone LLMs in AI Agents](https://arxiv.org/abs/2510.22620)
 - [DeepSeek-OCR: Contexts Optical Compression](https://arxiv.org/pdf/2510.18234)
 - [A2AS: Agentic AI Runtime Security and Self-Defense](https://arxiv.org/pdf/2510.13825)

--- a/learning/reasoning.md
+++ b/learning/reasoning.md
@@ -34,6 +34,9 @@
 9. [Embarrassingly Simple Self-Distillation Improves Code Generation](https://arxiv.org/abs/2604.01193) (Zhang et al., 2026)
    - *Why*: **Self-distillation for code generation** - shows that sampling solutions at a tuned temperature and retraining on them lifts Qwen3-30B-Instruct's LiveCodeBench v6 pass@1 from 42.4% to 55.3%, with the largest gains on hard problems; frames the improvement as resolving a precision-exploration conflict in decoding by suppressing unhelpful token variations while preserving useful exploratory diversity.
 
+10. [Scaling Latent Reasoning via Looped Language Models](https://arxiv.org/abs/2510.25741) (Zhu et al., 2025)
+    - *Why*: **Reasoning baked into pretraining via weight-shared loops** - introduces Ouro, a family of looped LMs that perform iterative computation in latent space with an entropy-regularized objective for learned depth allocation, pretrained on 7.7T tokens; the 1.4B and 2.6B variants reportedly match 12B-parameter baselines, with gains traced to better knowledge manipulation rather than larger storage capacity, suggesting latent recurrence is an alternative axis to chain-of-thought for scaling reasoning.
+
 ## Agentic Systems
 **Goal**: Create autonomous AI agents
 


### PR DESCRIPTION
## Summary
- Adds Ouro (Zhu et al., 2025) to `learning/reasoning.md` under "Teaching Models to Reason"
- Adds entry to `by-date.md` under 2025.10

## Test plan
- [x] Topic file entry follows existing numbered format
- [x] by-date.md entry placed in correct month section

🤖 Generated with [Claude Code](https://claude.com/claude-code)