### PR TITLE
Add paper: A Formal Comparison Between Chain of Thought and Latent Thought (2025)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -43,6 +43,7 @@
 - [Less is More: Recursive Reasoning with Tiny Networks](https://arxiv.org/pdf/2510.04871)
 
 ### 2025.09
+- [A Formal Comparison Between Chain of Thought and Latent Thought](https://arxiv.org/abs/2509.25239) (Xu et al., 2025)
 - [Learning in Stackelberg Mean Field Games: A Non-Asymptotic Analysis](https://arxiv.org/pdf/2509.15392)
 - [Federated Learning with Ad-hoc Adapter Insertions: The Case of Soft-Embeddings for Training Classifier-as-Retriever](https://arxiv.org/pdf/2509.16508)
 - [An AI system to help scientists write expert-level empirical software](https://arxiv.org/pdf/2509.06503)

--- a/learning/reasoning.md
+++ b/learning/reasoning.md
@@ -37,6 +37,9 @@
 10. [Scaling Latent Reasoning via Looped Language Models](https://arxiv.org/abs/2510.25741) (Zhu et al., 2025)
     - *Why*: **Reasoning baked into pretraining via weight-shared loops** - introduces Ouro, a family of looped LMs that perform iterative computation in latent space with an entropy-regularized objective for learned depth allocation, pretrained on 7.7T tokens; the 1.4B and 2.6B variants reportedly match 12B-parameter baselines, with gains traced to better knowledge manipulation rather than larger storage capacity, suggesting latent recurrence is an alternative axis to chain-of-thought for scaling reasoning.
 
+11. [A Formal Comparison Between Chain of Thought and Latent Thought](https://arxiv.org/abs/2509.25239) (Xu et al., 2025)
+    - *Why*: **Theoretical separation between CoT and latent reasoning** - proves that latent thought enables more efficient parallel computation than the inherently sequential CoT, while CoT uniquely supports approximate counting and sampling via stochastic decoding; gives principled guidance for choosing between discrete-token and continuous-representation reasoning based on whether a task needs iterative recursion, depth, or stochasticity.
+
 ## Agentic Systems
 **Goal**: Create autonomous AI agents
 


### PR DESCRIPTION
## Summary
- Adds Xu et al. (2025), "A Formal Comparison Between Chain of Thought and Latent Thought" (arXiv:2509.25239) to `learning/reasoning.md` under "Teaching Models to Reason" as entry #11.
- Adds a corresponding bullet to `by-date.md` under 2025.09.

## Test plan
- [x] Topic file entry follows numbered format with arXiv abstract URL and 1-2 sentence *Why*.
- [x] Chronological entry placed under correct YYYY.MM heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)