### PR TITLE
Add paper: Biologically Inspired Rectified Spectral Units (ReSUs) (2025)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -22,6 +22,7 @@
 ## 2025
 
 ### 2025.12
+- [A Network of Biologically Inspired Rectified Spectral Units (ReSUs) Learns Hierarchical Features Without Error Backpropagation](https://arxiv.org/abs/2512.23146) (Qin et al., 2025)
 - [H-Neurons: On the Existence, Impact, and Origin of Hallucination-Associated Neurons in LLMs](https://arxiv.org/abs/2512.01797) (Gao et al., Tsinghua, 2025)
 - [Recursive Language Models](https://arxiv.org/abs/2512.24601)
 - [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880)

--- a/learning/architectures.md
+++ b/learning/architectures.md
@@ -40,6 +40,9 @@
 11. [LeWorldModel: Stable End-to-End Joint-Embedding Predictive Architecture from Pixels](https://arxiv.org/abs/2603.19312) (Maes et al., 2026)
    - *Why*: **First stable end-to-end JEPA from raw pixels** - trains a Joint Embedding Predictive Architecture using only a prediction loss and a Gaussian regularizer, eliminating the complex multi-term losses and EMA tricks prior JEPAs required; plans up to 48x faster than foundation-model-based world models on 2D/3D control tasks with ~15M parameters on a single GPU
 
+12. [A Network of Biologically Inspired Rectified Spectral Units (ReSUs) Learns Hierarchical Features Without Error Backpropagation](https://arxiv.org/abs/2512.23146) (Qin et al., 2025)
+   - *Why*: **Backprop-free hierarchical feature learning grounded in biology** - introduces Rectified Spectral Units that learn locally via canonical correlation analysis on input history, encoding information in synaptic weights and temporal filters; a two-layer network trained on natural scenes spontaneously develops temporal filters matching Drosophila post-photoreceptor neurons and direction-selective second-layer units resembling connectome-derived motion detectors, offering both a model of sensory circuits and a credible alternative to error backpropagation
+
 ## Theoretical Foundations
 **Goal**: Understand the mathematical foundations
 


### PR DESCRIPTION
## Summary
- Adds [A Network of Biologically Inspired Rectified Spectral Units (ReSUs) Learns Hierarchical Features Without Error Backpropagation](https://arxiv.org/abs/2512.23146) (Qin et al., 2025) to `learning/architectures.md` under **Alternative Architectures**.
- Adds chronological entry to `by-date.md` under **2025.12**.

## Test plan
- [x] Entry follows existing format (numbered, arXiv abstract link, 1-2 sentence *Why*)
- [x] Date `2025.12` matches arXiv ID prefix `2512`
- [x] No emoji on research paper entry (per CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)