### PR TITLE
Add paper: SSA: Sparse Sparse Attention (2025)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -29,6 +29,7 @@
 - 📄 [New York State A6453A/S6953B: Training and Use of Artificial Intelligence Frontier Models](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (Signed December 2025)
 
 ### 2025.11
+- [SSA: Sparse Sparse Attention by Aligning Full and Sparse Attention Outputs in Feature Space](https://arxiv.org/abs/2511.20102) (Shen et al., 2025)
 - [SEC-bench: Automated Benchmarking of LLM Agents on Real-World Software Security Tasks](https://openreview.net/pdf?id=QQhQIqons0)
 - [Embedded Universal Predictive Intelligence: a coherent framework for multi-agent learning](https://arxiv.org/pdf/2511.22226)
 - [Weight-sparse transformers have interpretable circuits](https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf) (OpenAI, Nov 13, 2025)

--- a/learning/attention.md
+++ b/learning/attention.md
@@ -25,6 +25,9 @@
 6. [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/abs/2502.11089) (2025)
    - *Why*: **Trainable sparse attention aligned to GPU hardware** - designs sparsity patterns that map directly to GPU memory hierarchies and tensor core operations, avoiding the overhead of unstructured sparse kernels; trains the sparsity pattern end-to-end rather than applying it post-hoc; maintains dense-attention quality at a fraction of the compute cost for long sequences
 
+7. [SSA: Sparse Sparse Attention by Aligning Full and Sparse Attention Outputs in Feature Space](https://arxiv.org/abs/2511.20102) (Shen et al., 2025)
+   - *Why*: **Bridges the sparse/full attention divide** - diagnoses the *attention gap* (sparse inference on full-attention-trained models degrades quality) and the *capability gap* (pure sparse training loses gradient signal), then jointly trains both modes with bidirectional output alignment in feature space; theory bounds the approximation error linearly in the dropped attention mass, and a single trained model adapts to variable sparsity levels at inference, excelling on long-context inputs
+
 ## Long Context & Compression
 **Goal**: Handle longer sequences efficiently
 


### PR DESCRIPTION
## Summary
- Adds *SSA: Sparse Sparse Attention by Aligning Full and Sparse Attention Outputs in Feature Space* (Shen et al., 2025) to `learning/attention.md` under "Efficient Attention" (entry 7), next to Native Sparse Attention.
- Adds the paper to `by-date.md` under `2025.11`.

## Test plan
- [x] Entry follows the numbered format with a 1-2 sentence "Why"
- [x] arXiv abstract URL used
- [x] Chronological index updated under correct YYYY.MM heading