### PR TITLE
Add paper: Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers (2026)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -2,6 +2,9 @@
 
 ## 2026
 
+### 2026.05
+- [Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers](https://arxiv.org/abs/2605.10901) (Kezins et al., 2026)
+
 ### 2026.04
 - [MegaTrain: Full Precision Training of 100B+ Parameter Large Language Models on a Single GPU](https://arxiv.org/abs/2604.05091) (Yuan et al., 2026)
 - [Your Agent Is Mine: Measuring Malicious Intermediary Attacks on the LLM Supply Chain](https://arxiv.org/abs/2604.08407) (Liu et al., 2026)

--- a/learning/safety.md
+++ b/learning/safety.md
@@ -77,6 +77,9 @@ As AI systems control increasingly important decisions—from content moderation
 7. [Agents of Chaos](https://arxiv.org/abs/2602.20021) (Shapira et al., 2026)
    - *Why*: Empirical red-teaming of autonomous LLM agents with persistent memory, email, shell access, and multi-agent communication in a live environment; documents eleven failure modes including unauthorized compliance, identity spoofing, cross-agent propagation, and partial system takeover
 
+8. [Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers](https://arxiv.org/abs/2605.10901) (Kezins et al., 2026)
+   - *Why*: Shifts guardrail verification from discrete input space to the classifier's pre-activation layer, where harmful prompts form convex regions certifiable via monotonicity of the sigmoid head; introduces SVD-aligned hyper-rectangles (exact) and Gaussian Mixture Models (probabilistic) for region construction, exposing large safety gaps in BERT (55-90% coverage) versus more stable GPT-2/Llama classifiers (~80-90%)
+
 ## Bias, Fairness & Robustness
 **Goal**: Detect, measure, and mitigate bias in AI systems while maintaining robustness
 


### PR DESCRIPTION
## Summary
- Adds Kezins et al. 2026 "Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers" to `learning/safety.md` under Safety Evaluation & Red Teaming.
- Adds a new `### 2026.05` entry at the top of `by-date.md`.

## Test plan
- [x] Entry follows existing numbered format with arXiv abstract URL
- [x] Chronological index in reverse-chronological order

🤖 Generated with [Claude Code](https://claude.com/claude-code)