### PR TITLE
Add paper: DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation (2026)

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -2,6 +2,9 @@
 
 ## 2026
 
+### 2026.06
+- [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf) (Cheng et al., 2026)
+
 ### 2026.05
 - [If LLMs Have Human-Like Attributes, Then So Does Age of Empires II](https://arxiv.org/abs/2605.31514) (de Wynter, 2026)
 - [Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers](https://arxiv.org/abs/2605.10901) (Kezins et al., 2026)

--- a/learning/language-models.md
+++ b/learning/language-models.md
@@ -73,6 +73,9 @@
 5. [Do LLMs Benefit From Their Own Words?](https://arxiv.org/abs/2602.24287) (Huang et al., 2026)
    - *Why*: Shows that omitting prior assistant responses in multi-turn context often preserves quality while cutting context length; identifies context pollution and motivates selective context filtering.
 
+6. [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf) (Cheng et al., 2026)
+   - *Why*: **Load-aware speculative decoding** - couples a parallel drafter with a lightweight sequential module (semi-autoregressive) to add intra-block dependencies and slow acceptance decay, then confidence-schedules verification length per request; deployed in DeepSeek-V4 serving, it lifts per-user generation speed 60–85% at matched throughput.
+
 ---
 
 **Related**: [Foundations](foundations.md) | [Attention](attention.md) | [Retrieval](retrieval.md)


### PR DESCRIPTION
Adds DSpark (DeepSeek-AI & Peking University, 2026) to the learning index and chronological list.

- **Topic**: `learning/language-models.md` → Memory & Efficiency Optimizations
- **Chronological**: new `### 2026.06` section in `by-date.md`

DSpark is a speculative-decoding framework pairing a parallel drafter with a lightweight sequential module (semi-autoregressive) and load-aware confidence-scheduled verification; deployed in DeepSeek-V4 serving, it accelerates per-user generation 60–85% at matched throughput.

🤖 Generated with [Claude Code](https://claude.com/claude-code)