### PR TITLE
Fix broken DSpark link and correct its date to 2026.07

### DIFF
--- a/by-date.md
+++ b/by-date.md
@@ -4,9 +4,7 @@
 
 ### 2026.07
 - [Bad Memory: Evaluating Prompt Injection Risks from Memory in Agentic Systems](https://arxiv.org/abs/2607.14611) (Gadgil et al., 2026)
-
-### 2026.06
-- [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf) (Cheng et al., 2026)
+- [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://arxiv.org/abs/2607.05147) (Cheng et al., 2026)
 
 ### 2026.05
 - [If LLMs Have Human-Like Attributes, Then So Does Age of Empires II](https://arxiv.org/abs/2605.31514) (de Wynter, 2026)

--- a/learning/language-models.md
+++ b/learning/language-models.md
@@ -73,7 +73,7 @@
 5. [Do LLMs Benefit From Their Own Words?](https://arxiv.org/abs/2602.24287) (Huang et al., 2026)
    - *Why*: Shows that omitting prior assistant responses in multi-turn context often preserves quality while cutting context length; identifies context pollution and motivates selective context filtering.
 
-6. [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf) (Cheng et al., 2026)
+6. [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://arxiv.org/abs/2607.05147) (Cheng et al., 2026)
    - *Why*: **Load-aware speculative decoding** - couples a parallel drafter with a lightweight sequential module (semi-autoregressive) to add intra-block dependencies and slow acceptance decay, then confidence-schedules verification length per request; deployed in DeepSeek-V4 serving, it lifts per-user generation speed 60–85% at matched throughput.
 
 ---


### PR DESCRIPTION
The DSpark entry linked to `https://github.com/deepseek-ai/DeepSpec/blob/main/DSpark_paper.pdf`, which returns **404** — the DeepSpec repo exists but has never contained that PDF.

The paper is on arXiv at [2607.05147](https://arxiv.org/abs/2607.05147). The DeepSpec README's own BibTeX block points there, and the title and first author (Xin Cheng) match the existing entry exactly.

**Two fixes:**
1. **Link** → arXiv abstract URL, per the repo's preferred link style.
2. **Date** → arXiv lists "Submitted on 6 Jul 2026", so the paper moves from `2026.06` to `2026.07`. That leaves `2026.06` empty, so the heading is removed.

Updated in both `by-date.md` and `learning/language-models.md`. Both remaining URLs verified 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)