### PR TITLE
Audit and refresh AI regulation domain; correct repo indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 > A curated, pedagogically-organized collection of essential research papers spanning the landscape of modern artificial intelligence and machine learning.
 
-[![Papers](https://img.shields.io/badge/papers-235+-blue.svg)](by-date.md)
+[![Papers](https://img.shields.io/badge/papers-267-blue.svg)](by-date.md)
 [![Learning Path](https://img.shields.io/badge/learning-14_areas-green.svg)](learning-path.md)
-[![Glossary](https://img.shields.io/badge/glossary-250+_terms-purple.svg)](learning/glossary.md)
+[![Glossary](https://img.shields.io/badge/glossary-160_terms-purple.svg)](learning/glossary.md)
 
 ---
 
 ## 🎯 What's Inside
 
-This repository contains **235+ carefully selected research papers and policy documents** organized in three complementary ways:
+This repository contains **267 carefully selected research papers and policy documents** organized in three complementary ways:
 
 1. **📚 [Structured Learning Path](learning-path.md)** - Topic areas and curated tracks from foundations to cutting-edge research
-2. **📅 [Chronological Timeline](by-date.md)** - Papers organized by publication date (1997-2025)
-3. **📖 [Comprehensive Glossary](learning/glossary.md)** - 250+ terms, concepts, and acronyms explained with context
+2. **📅 [Chronological Timeline](by-date.md)** - Papers organized by publication date (1997-2026)
+3. **📖 [Comprehensive Glossary](learning/glossary.md)** - 160 terms, concepts, and acronyms explained with context
 
 **Plus**: [Recommended tracks](#-how-to-use-this-repository), [notes on learning](#paper-reading-tips), and [quick start guides](#-quick-start) tailored to your role (beginner, practitioner, researcher, engineer, security specialist).
 
@@ -32,13 +32,13 @@ Jump to relevant areas:
 - **Production AI**: [Retrieval](learning/retrieval.md) (RAG), [Safety](learning/safety.md) (Security & Safety)
 
 ### For Researchers
-Browse the **[Chronological View](by-date.md)** to see latest 2025 research, or deep-dive into:
+Browse the **[Chronological View](by-date.md)** to see latest 2026 research, or deep-dive into:
 - [Alternative Architectures](learning/architectures.md)
 - [Interpretability](learning/interpretability.md)
 - [Advanced Topics](learning/advanced.md)
 
 ### Quick Reference
-**Need a definition?** → Check the **[📖 Glossary](learning/glossary.md)** for 250+ terms organized by category (architectures, training, NLP, security, etc.)
+**Need a definition?** → Check the **[📖 Glossary](learning/glossary.md)** for 160 terms organized by category (architectures, training, NLP, security, etc.)
 
 ---
 
@@ -92,21 +92,21 @@ The learning path is organized into **14 topic areas**; use [learning-path.md](l
 | Area | Topic | Papers | Focus |
 |------|-------|--------|-------|
 | **[Foundations](learning/foundations.md)** | 🏗️ **Foundations** | 25 | Deep learning basics, embeddings, CNNs, RNNs, GANs, tokenization |
-| **[Language Models](learning/language-models.md)** | 🤖 **Large Language Models** | 20 | Transformers, BERT, GPT, training at scale |
-| **[Attention](learning/attention.md)** | ⚡ **Attention Innovations** | 10 | FlashAttention 1 & 2, efficient attention, long context |
+| **[Language Models](learning/language-models.md)** | 🤖 **Large Language Models** | 21 | Transformers, BERT, GPT, training at scale |
+| **[Attention](learning/attention.md)** | ⚡ **Attention Innovations** | 11 | FlashAttention 1 & 2, efficient attention, long context |
 | **[Retrieval](learning/retrieval.md)** | 🔍 **Retrieval & RAG** | 11 | THE RAG paper, dense retrieval, kNN-LM, semantic search |
-| **[Reasoning](learning/reasoning.md)** | 🧠 **Reasoning & Agents** | 19 | RLHF, chain-of-thought, agentic systems |
-| **[Architectures](learning/architectures.md)** | 🏛️ **Alternative Architectures** | 16 | RWKV, Mamba, state-space models, theory |
+| **[Reasoning](learning/reasoning.md)** | 🧠 **Reasoning & Agents** | 22 | RLHF, chain-of-thought, agentic systems |
+| **[Architectures](learning/architectures.md)** | 🏛️ **Alternative Architectures** | 17 | RWKV, Mamba, state-space models, theory |
 | **[Interpretability](learning/interpretability.md)** | 🔬 **Interpretability** | 16 | LIME, integrated gradients, weight-sparse circuits |
-| **[Safety](learning/safety.md)** | 🛡️ **Security, Safety & Robustness** | 34 | Alignment, security threats, safety evaluation, bias & fairness, harmful content, long-term safety |
-| **[Advanced](learning/advanced.md)** | 🎯 **Advanced Applications** | 8 | Multimodal, scientific AI, test-time compute |
+| **[Safety](learning/safety.md)** | 🛡️ **Security, Safety & Robustness** | 36 | Alignment, security threats, safety evaluation, bias & fairness, harmful content, long-term safety |
+| **[Advanced](learning/advanced.md)** | 🎯 **Advanced Applications** | 9 | Multimodal, scientific AI, test-time compute |
 | **[Probabilistic](learning/probabilistic.md)** | 🎲 **Probabilistic Models** | 9 | Diffusion, probabilistic programming |
 | **[Vision](learning/vision.md)** | 👁️ **Vision & Multimodal** | 11 | ViT, CLIP, SAM, LLaVA, vision-language models |
 | **[Hardware](learning/hardware.md)** | ⚙️ **Hardware & Systems** | 5 | GPU optimization, inference scaling, photonic computing |
 | **[Human-AI Interaction](learning/human-ai-interaction.md)** | 🧠 **Human-AI Interaction** | 11 | Trust, automation bias, cognitive effects, human-AI teams |
-| **[Policy](learning/policy.md)** | 📜 **Policy & Governance** | 42 | GDPR, EU AI Act, NIST AI RMF, OCC model risk guidance |
+| **[Policy](learning/policy.md)** | 📜 **Policy & Governance** | 63 | GDPR, EU AI Act, US federal & state AI law, NIST AI RMF |
 
-**Total**: 237 papers across 14 areas (including 42 policy documents & frameworks)
+**Total**: 267 papers across 14 areas (including 63 policy documents & frameworks)
 
 ---
 
@@ -171,7 +171,7 @@ This collection spans the full spectrum of modern AI/ML research, organized by t
 - **Red Teaming & Evaluation**: [Red Teaming Language Models](https://arxiv.org/abs/2209.07858), [GPTFuzzer](https://arxiv.org/pdf/2309.10253), [HarmBench](https://arxiv.org/abs/2402.04249), [WMDP](https://arxiv.org/abs/2403.03218), [TruthfulQA](https://arxiv.org/abs/2109.07958)
 - **Bias & Fairness**: [Equality of Opportunity](https://arxiv.org/abs/1610.02413), [Gender Shades](http://proceedings.mlr.press/v81/buolamwini18a.html), [Tokenization bias](https://arxiv.org/abs/2406.16829), [model calibration](https://arxiv.org/abs/1706.04599)
 - **Harmful Content**: [RealToxicityPrompts](https://arxiv.org/abs/2009.11462)
-- **Long-term Safety**: [Sleeper Agents](https://arxiv.org/abs/2401.05566), [AI Safety Gridworlds](https://arxiv.org/abs/1711.09883), [Scalable oversight](https://www.anthropic.com/research/scalable-oversight), [Guaranteed Safe AI](https://arxiv.org/abs/2405.06624)
+- **Long-term Safety**: [Sleeper Agents](https://arxiv.org/abs/2401.05566), [AI Safety Gridworlds](https://arxiv.org/abs/1711.09883), [Scalable oversight](https://www.anthropic.com/research/measuring-progress-on-scalable-oversight-for-large-language-models), [Guaranteed Safe AI](https://arxiv.org/abs/2405.06624)
 
 ### 👁️ Computer Vision & Multimodal AI
 - Vision transformers: [ViT](https://arxiv.org/abs/2010.11929), [CLIP](https://arxiv.org/abs/2103.00020), [SAM](https://arxiv.org/abs/2304.02643)
@@ -192,9 +192,9 @@ This collection spans the full spectrum of modern AI/ML research, organized by t
 - **Test-time compute**: [o3 system](https://arxiv.org/pdf/2411.04996), [consciousness in AI](https://arxiv.org/pdf/2308.08708v3.pdf)
 
 ### 🎲 Probabilistic & Generative Models
-- Probabilistic programming: [Data analysis](https://papers.nips.cc/paper/6060-a-probabilistic-programming-approach-to-probabilistic-data-analysis.pdf), [scene perception](https://openaccess.thecvf.com/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf) (Picture)
+- Probabilistic programming: [Data analysis](https://papers.nips.cc/paper/6060-a-probabilistic-programming-approach-to-probabilistic-data-analysis.pdf), [scene perception](https://www.cv-foundation.org/openaccess/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf) (Picture)
 - MCMC methods: [Hamiltonian dynamics](https://arxiv.org/abs/1206.1901)
-- Bayesian approaches: [Intuitive dynamics modeling](https://cocosci.berkeley.edu/tom/papers/collisions.pdf) 🔒
+- Bayesian approaches: [Intuitive dynamics modeling](https://cocosci.princeton.edu/tom/papers/collisions.pdf)
 
 ### ⚙️ Hardware & Systems
 - Photonic computing for AI 🔒
@@ -202,12 +202,14 @@ This collection spans the full spectrum of modern AI/ML research, organized by t
 - Hardware-algorithm co-design
 
 ### 📜 Policy & Governance
-- **Financial services**: [OCC 2011-12](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12a.pdf) (Model Risk Management), [SR 11-7](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) (Federal Reserve), [Model Risk Handbook](https://www.occ.gov/publications-and-resources/publications/comptrollers-handbook/files/model-risk-management/index-model-risk-management.html)
+- **Financial services**: [OCC 2011-12](https://web.archive.org/web/20240616095814/https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12a.pdf) (Model Risk Management), [SR 11-7](https://web.archive.org/web/20250103073254/https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) (Federal Reserve), [FDIC adoption notice](https://www.fdic.gov/news/inactive-financial-institution-letters/2017/adoption-supervisory-guidance-model-risk-management)
 - **Data protection**: [GDPR](https://gdpr-info.eu/) (EU), [CCPA/CPRA](https://oag.ca.gov/privacy/ccpa) (California), [Convention 108+](https://www.coe.int/en/web/data-protection/convention108-and-protocol)
-- **AI legislation**: [EU AI Act](https://artificialintelligenceact.eu/), [Executive Order 14110](https://www.whitehouse.gov/briefing-room/presidential-actions/2023/10/30/executive-order-on-the-safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence/), [Blueprint for AI Bill of Rights](https://www.whitehouse.gov/ostp/ai-bill-of-rights/), [China's Generative AI regulations](http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm), [New York State Frontier AI Model Law](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (A6453A/S6953B)
-- **Standards & frameworks**: [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework), [ISO/IEC 42001](https://www.iso.org/standard/81230.html), [IEEE 7000 series](https://standards.ieee.org/featured/artificial-intelligence-systems/), [OECD AI Principles](https://oecd.ai/en/ai-principles)
-- **Sector-specific**: [FDA AI/ML guidance](https://www.fda.gov/medical-devices/software-medical-device-samd/artificial-intelligence-and-machine-learning-aiml-enabled-medical-devices), [EEOC AI discrimination guidance](https://www.eeoc.gov/laws/guidance/what-you-should-know-about-using-artificial-intelligence-when-making-employment), [NYC Local Law 144](https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page)
-- **National security**: [Dual-use models report](https://www.ntia.gov/sites/default/files/publications/ntia-ai-open-model-report.pdf), [Export controls](https://www.bis.gov/index.php/emerging-tech-and-ai-controls), [NSCAI report](https://www.nscai.gov/2021-final-report/)
+- **International AI law**: [EU AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj) (Reg. (EU) 2024/1689), [GPAI Code of Practice](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai), [CoE Framework Convention on AI](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence) (CETS 225), [Korea Framework Act on AI](https://www.law.go.kr/LSW/eng/engLsSc.do?menuId=2&query=ARTIFICIAL+INTELLIGENCE), [China's Generative AI regulations](http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm) and [AI content labeling measures](https://www.cac.gov.cn/2025-03/14/c_1743654684782215.htm)
+- **US federal**: [EO 14179](https://www.federalregister.gov/documents/2025/01/31/2025-02172/removing-barriers-to-american-leadership-in-artificial-intelligence), [America's AI Action Plan](https://www.ai.gov/action-plan), [EO 14365](https://www.federalregister.gov/documents/2025/12/16/2025-23092/ensuring-a-national-policy-framework-for-artificial-intelligence) (state-law preemption) — plus [EO 14110](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence) and the [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/), both rescinded in 2025 but retained for context
+- **US states**: [California SB 53](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB53) (first frontier-AI statute), [California SB 243](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB243) (companion chatbots), [Texas TRAIGA](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=HB149), [Colorado SB 26-189](https://leg.colorado.gov/bills/sb26-189), [New York RAISE Act](https://www.nysenate.gov/legislation/bills/2025/S6953)
+- **Standards & frameworks**: [NIST AI RMF](https://www.nist.gov/itl/ai-risk-management-framework), [NIST AI 600-1 GenAI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf), [ISO/IEC 42001](https://www.iso.org/standard/81230.html), [IEEE 7000 series](https://standards.ieee.org/initiatives/autonomous-intelligence-systems/standards/), [OECD AI Principles](https://oecd.ai/en/ai-principles)
+- **Sector-specific**: [FDA AI/ML guidance](https://www.fda.gov/medical-devices/software-medical-device-samd/artificial-intelligence-and-machine-learning-aiml-enabled-medical-devices), [EEOC AI discrimination guidance](https://web.archive.org/web/20240527151347/https://www.eeoc.gov/laws/guidance/select-issues-assessing-adverse-impact-software-algorithms-and-artificial) (withdrawn 2025), [NYC Local Law 144](https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page)
+- **National security**: [Dual-use models report](https://www.ntia.gov/sites/default/files/publications/ntia-ai-open-model-report.pdf), [Export controls](https://www.bis.doc.gov/index.php/policy-guidance/advanced-computing-and-semiconductor-manufacturing-items), [NSCAI report](https://web.archive.org/web/20240104154550/https://www.nscai.gov/2021-final-report/)
 - **Responsible AI**: [Model cards](https://arxiv.org/abs/1810.03993), [Datasheets for datasets](https://arxiv.org/abs/1803.09010), [Microsoft Responsible AI Standard](https://www.microsoft.com/en-us/ai/responsible-ai), [AI Incident Database](https://incidentdatabase.ai/)
 
 ---

--- a/by-date.md
+++ b/by-date.md
@@ -7,6 +7,7 @@
 - [DSpark: Confidence-Scheduled Speculative Decoding with Semi-Autoregressive Generation](https://arxiv.org/abs/2607.05147) (Cheng et al., 2026)
 
 ### 2026.05
+- 📄 [Colorado SB 26-189: Automated Decision-Making Technology](https://leg.colorado.gov/bills/sb26-189) (Colorado, signed May 14, 2026 — repeals and replaces the 2024 Colorado AI Act)
 - [If LLMs Have Human-Like Attributes, Then So Does Age of Empires II](https://arxiv.org/abs/2605.31514) (de Wynter, 2026)
 - [Beyond Red-Teaming: Formal Guarantees of LLM Guardrail Classifiers](https://arxiv.org/abs/2605.10901) (Kezins et al., 2026)
 - [Lattice Deduction Transformers](https://arxiv.org/abs/2605.08605) (Davis et al., 2026)
@@ -26,6 +27,7 @@
 - [Do LLMs Benefit From Their Own Words?](https://arxiv.org/abs/2602.24287) (Huang et al., 2026)
 
 ### 2026.01
+- 📄 [Framework Act on Artificial Intelligence Development and Trust Base Creation](https://www.law.go.kr/LSW/eng/engLsSc.do?menuId=2&query=ARTIFICIAL+INTELLIGENCE) (South Korea, effective January 22, 2026)
 - [NL2LOGIC: AST-Guided Translation of Natural Language into First-Order Logic with Large Language Models](https://arxiv.org/abs/2602.13237) (Putra et al., 2026)
 - [Thinking—Fast, Slow, and Artificial: How AI is Reshaping Human Reasoning and the Rise of Cognitive Surrender](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6097646) (Shaw & Nave, 2026)
 
@@ -38,7 +40,8 @@
 - [H-Neurons: On the Existence, Impact, and Origin of Hallucination-Associated Neurons in LLMs](https://arxiv.org/abs/2512.01797) (Gao et al., Tsinghua, 2025)
 - [Recursive Language Models](https://arxiv.org/abs/2512.24601)
 - [mHC: Manifold-Constrained Hyper-Connections](https://arxiv.org/abs/2512.24880)
-- 📄 [New York State A6453A/S6953B: Training and Use of Artificial Intelligence Frontier Models](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (Signed December 2025)
+- 📄 [Executive Order 14365: Ensuring a National Policy Framework for Artificial Intelligence](https://www.federalregister.gov/documents/2025/12/16/2025-23092/ensuring-a-national-policy-framework-for-artificial-intelligence) (US, signed December 11, 2025)
+- 📄 [New York S6953B/A6453B: Responsible AI Safety and Education (RAISE) Act](https://www.nysenate.gov/legislation/bills/2025/S6953) (New York, signed December 19, 2025; chapter amendment March 27, 2026; effective January 1, 2027)
 
 ### 2025.11
 - [SSA: Sparse Sparse Attention by Aligning Full and Sparse Attention Outputs in Feature Space](https://arxiv.org/abs/2511.20102) (Shen et al., 2025)
@@ -46,6 +49,7 @@
 - [Embedded Universal Predictive Intelligence: a coherent framework for multi-agent learning](https://arxiv.org/pdf/2511.22226)
 - [Weight-sparse transformers have interpretable circuits](https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf) (OpenAI, Nov 13, 2025)
 - [Nested Learning: The Illusion of Deep Learning Architectures](https://abehrouz.github.io/files/NL.pdf) - NeurIPS 2025
+- 📄 [Framework Convention on Artificial Intelligence and Human Rights, Democracy and the Rule of Law (CETS No. 225)](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence) (Council of Europe, entered into force November 1, 2025)
 
 ### 2025.10
 - [Scaling Latent Reasoning via Looped Language Models](https://arxiv.org/abs/2510.25741) (Zhu et al., 2025)
@@ -55,6 +59,7 @@
 - [The Potential of Second-Order Optimization for LLMs: A Study with Full Gauss-Newton](https://arxiv.org/pdf/2510.09378)
 - [Agentic Context Engineering: Evolving Contexts for Self-Improving Language Models](https://arxiv.org/abs/2510.04618)
 - [Less is More: Recursive Reasoning with Tiny Networks](https://arxiv.org/pdf/2510.04871)
+- 📄 [California SB 243: Companion Chatbots](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB243) (California, signed October 13, 2025)
 
 ### 2025.09
 - [A Formal Comparison Between Chain of Thought and Latent Thought](https://arxiv.org/abs/2509.25239) (Xu et al., 2025)
@@ -62,6 +67,7 @@
 - [Federated Learning with Ad-hoc Adapter Insertions: The Case of Soft-Embeddings for Training Classifier-as-Retriever](https://arxiv.org/pdf/2509.16508)
 - [An AI system to help scientists write expert-level empirical software](https://arxiv.org/pdf/2509.06503)
 - [REFRAG: Rethinking RAG based Decoding](https://arxiv.org/pdf/2509.01092)
+- 📄 [California SB 53: Transparency in Frontier Artificial Intelligence Act](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB53) (California, signed September 29, 2025)
 
 ### 2025.08
 - [Semantic IDs for Joint Generative Search and Recommendation](https://arxiv.org/abs/2508.10478)
@@ -70,6 +76,8 @@
 - [A Survey of Context Engineering for Large Language Models](https://arxiv.org/abs/2507.13334) (Mei et al., 2025)
 - [Subliminal Learning: Language Models Transmit Behavioral Traits via Hidden Signals in Data](https://arxiv.org/pdf/2507.14805) (Cloud et al., 2025)
 - [AlphaGo Moment for Model Architecture Discovery](https://arxiv.org/pdf/2507.18074)
+- 📄 [Winning the AI Race: America's AI Action Plan](https://www.ai.gov/action-plan) (US, July 2025)
+- 📄 [General-Purpose AI Code of Practice](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) (European Commission, July 10, 2025)
 
 ### 2025.06
 - [Artificial Intelligent Disobedience: Rethinking the Agency of Our Artificial Teammates](https://arxiv.org/abs/2506.22276) (Mirsky, 2025)
@@ -77,6 +85,7 @@
 - [Hierarchical Reasoning Model](https://arxiv.org/pdf/2506.21734)
 - [Small Language Models are the Future of Agentic AI](https://arxiv.org/abs/2506.02153)
 - [Reinforcement Pre-Training](https://arxiv.org/abs/2506.08007)
+- 📄 [Texas HB 149: Responsible Artificial Intelligence Governance Act (TRAIGA)](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=HB149) (Texas, signed June 22, 2025)
 
 ### 2025.05
 - [Why Diffusion Models Don't Memorize: The Role of Implicit Dynamical Regularization in Training](https://arxiv.org/pdf/2505.17638)
@@ -91,11 +100,15 @@
 
 ### 2025.03
 - [Large Language Models are Unreliable for Cyber Threat Intelligence](https://arxiv.org/abs/2503.23175)
+- 📄 [Measures for Labeling AI-Generated Synthetic Content](https://www.cac.gov.cn/2025-03/14/c_1743654684782215.htm) (Cyberspace Administration of China, published March 14, 2025; effective September 1, 2025)
 
 ### 2025.02
 - [Forget What You Know about LLMs Evaluations -- LLMs are Like a Chameleon](https://arxiv.org/pdf/2502.07445)
 - [Native Sparse Attention: Hardware-Aligned and Natively Trainable Sparse Attention](https://arxiv.org/abs/2502.11089)
 - [The Illusion of Thinking](https://ml-site.cdn-apple.com/papers/the-illusion-of-thinking.pdf)
+
+### 2025.01
+- 📄 [Executive Order 14179: Removing Barriers to American Leadership in Artificial Intelligence](https://www.federalregister.gov/documents/2025/01/31/2025-02172/removing-barriers-to-american-leadership-in-artificial-intelligence) (US, signed January 23, 2025 — revokes EO 14110)
 
 ## 2024
 
@@ -198,7 +211,7 @@
 - [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629)
 
 ### 2022
-- [Scalable Oversight](https://www.anthropic.com/research/scalable-oversight) (Anthropic)
+- [Scalable Oversight](https://www.anthropic.com/research/measuring-progress-on-scalable-oversight-for-large-language-models) (Anthropic)
 - [Interpretability in the Wild: a Circuit for Indirect Object Identification in GPT-2 small](https://transformer-circuits.pub/2022/in-context-learning-and-induction-heads/index.html) (Anthropic)
 
 ### 2022.05
@@ -361,7 +374,7 @@
 - 🔒 [Algorithm Aversion: People Erroneously Avoid Algorithms After Seeing Them Err](https://psycnet.apa.org/record/2014-48748-001) (Dietvorst et al., 2015) - *Paywalled*
 
 ### 2015-CVPR
-- [Picture: An Imperative Probabilistic Programming Language for Scene Perception](https://openaccess.thecvf.com/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf)
+- [Picture: An Imperative Probabilistic Programming Language for Scene Perception](https://www.cv-foundation.org/openaccess/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf)
 
 ### 2015-Earlier
 - 🔒 [Deep Learning (Nature Review)](https://www.nature.com/articles/nature14539) - *Paywalled*
@@ -407,7 +420,7 @@
 
 ## 2009
 
-- 🔒 [A Bayesian Framework for Modeling Intuitive Dynamics](https://cocosci.berkeley.edu/tom/papers/collisions.pdf) - *May require institutional access*
+- [A Bayesian Framework for Modeling Intuitive Dynamics](https://cocosci.princeton.edu/tom/papers/collisions.pdf)
 
 ## 2004
 

--- a/learning-path.md
+++ b/learning-path.md
@@ -84,8 +84,8 @@ You can **follow a track** for a guided path, **jump to specific areas** based o
 
 - **[Policy, Safety & Societal Impact](learning/policy.md)**
   - Financial Services & Model Risk Management (OCC 2011-12, SR 11-7)
-  - Data Protection & Privacy Law (GDPR, CCPA)
-  - AI-Specific Legislation (EU AI Act, US Executive Orders)
+  - Data Protection & Privacy Law (GDPR, CCPA, CoE Framework Convention)
+  - AI-Specific Legislation (EU AI Act, US federal executive orders, US state laws, Korea, China)
   - Risk Management Frameworks (NIST AI RMF, ISO/IEC Standards)
   - Sector-Specific Guidance (Healthcare, Employment, Criminal Justice)
   - Dual-Use AI & National Security
@@ -152,4 +152,4 @@ Prioritize [Language Models](learning/language-models.md), [Attention](learning/
 
 ---
 
-*Last updated: March 23, 2026*
+*Last updated: July 22, 2026*

--- a/learning/policy.md
+++ b/learning/policy.md
@@ -11,17 +11,18 @@
 
 **Why this matters**: Financial institutions were among the first to systematically regulate AI/ML models. The frameworks developed here—particularly around model validation, governance, and risk management—have influenced AI regulation across industries.
 
-1. 📄 [OCC 2011-12: Supervisory Guidance on Model Risk Management](https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12a.pdf) (Office of the Comptroller of the Currency, 2011)
+1. 📄 [OCC 2011-12: Supervisory Guidance on Model Risk Management](https://web.archive.org/web/20240616095814/https://www.occ.gov/news-issuances/bulletins/2011/bulletin-2011-12a.pdf) (Office of the Comptroller of the Currency, 2011)
    - *Why*: **Foundational regulatory guidance** - establishes the three lines of defense for model risk management; defines what constitutes a "model" and requirements for validation
    - *Key concepts*: Model development, implementation, use; ongoing monitoring and validation; model inventory and governance
    - *Relevance*: Still the primary reference for ML model governance in banking; applicable beyond finance
+   - *Note*: OCC and Federal Reserve removed these pages from their live sites; archived copy linked. The FDIC's [adoption notice](https://www.fdic.gov/news/inactive-financial-institution-letters/2017/adoption-supervisory-guidance-model-risk-management) remains live and covers the same joint guidance
 
-2. 📄 [SR 11-7: Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) (Federal Reserve, 2011)
+2. 📄 [SR 11-7: Guidance on Model Risk Management](https://web.archive.org/web/20250103073254/https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm) (Federal Reserve, 2011)
    - *Why*: Federal Reserve's companion guidance to OCC 2011-12; emphasizes board and senior management oversight
    - *Key addition*: Focuses on governance structure and accountability frameworks
-   - *Note*: Identical substantive content to OCC 2011-12 but targets bank holding companies
+   - *Note*: Identical substantive content to OCC 2011-12 but targets bank holding companies; archived copy linked
 
-3. 📄 [Model Risk Management Handbook](https://www.occ.gov/publications-and-resources/publications/comptrollers-handbook/files/model-risk-management/index-model-risk-management.html) (OCC, Updated 2021)
+3. 📄 [Model Risk Management Handbook](https://web.archive.org/web/20241220200407/https://occ.gov/publications-and-resources/publications/comptrollers-handbook/files/model-risk-management/index-model-risk-management.html) (OCC, Updated 2021)
    - *Why*: Comprehensive implementation guide; covers AI/ML-specific considerations including explainability, data quality, and bias
    - *Practical value*: Real-world procedures for model validation, documentation standards, and audit practices
    - *Updates*: 2021 version explicitly addresses machine learning models and alternative data
@@ -55,6 +56,12 @@
    - *Why*: First binding international treaty on data protection; addresses AI explicitly
    - *Global scope*: Open to non-European countries
 
+4. 📄 [Framework Convention on Artificial Intelligence and Human Rights, Democracy and the Rule of Law (CETS No. 225)](https://www.coe.int/en/web/artificial-intelligence/the-framework-convention-on-artificial-intelligence) (Council of Europe, 2024)
+   - *Why*: **First binding international treaty on AI itself** - extends the Convention 108+ model from data protection to the full AI lifecycle; obliges parties to ensure AI activities are consistent with human rights, democracy and the rule of law
+   - *Scope*: Open to non-member states; signatories include the UK, France, Norway and the EU
+   - *Status*: Opened for signature 5 September 2024; entered into force 1 November 2025; ratified by the EU on 15 May 2026
+   - *Contrast*: Sets state-level obligations rather than product requirements, so it complements rather than duplicates the EU AI Act
+
 ---
 
 ## AI-Specific Legislation & Executive Action
@@ -62,8 +69,12 @@
 
 **Why this matters**: Unlike sector-specific rules, these frameworks regulate AI systems directly based on risk, use case, or capability level. They represent the future of AI governance.
 
-1. 📄 [EU Artificial Intelligence Act](https://artificialintelligenceact.eu/) (EU, 2024)
-   - *Why*: **World's first comprehensive AI law** - risk-based regulatory framework applicable from 2026
+> **Dates move.** Effective dates in this section have shifted repeatedly — the EU deferred its high-risk deadlines, Colorado repealed a law before it took effect, and New York rewrote one after signing. Everything below is stated as of **July 2026**; verify against the primary source before relying on it.
+
+### European Union
+
+1. 📄 [EU Artificial Intelligence Act (Regulation (EU) 2024/1689)](https://eur-lex.europa.eu/eli/reg/2024/1689/oj) (EU, 2024)
+   - *Why*: **World's first comprehensive AI law** - risk-based regulatory framework that has become the reference point most other jurisdictions define themselves against
    - *Risk tiers*:
      - Unacceptable risk: Banned (social scoring, real-time biometric surveillance)
      - High risk: Strict requirements (hiring, credit scoring, law enforcement)
@@ -71,42 +82,142 @@
      - Minimal risk: No requirements
    - *Key obligations*: Risk assessment, data quality, documentation, human oversight, accuracy requirements
    - *Foundation models*: Additional requirements for General Purpose AI (GPAI) and systemic risk models
-   - *Resources*: [Official text](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:52021PC0206) | [Practical guide](https://artificialintelligenceact.eu/the-act/)
+   - *Application timeline* (as of July 2026):
+     - Prohibited practices and AI literacy duties: 2 February 2025
+     - GPAI model obligations: 2 August 2025 (models already on the market have until 2 August 2027)
+     - Article 50 transparency duties: 2 August 2026 — **not deferred**
+     - Annex III standalone high-risk systems: deferred to 2 December 2027
+     - Annex I high-risk AI embedded in regulated products: deferred to 2 August 2028
+   - *Digital Omnibus on AI*: Commission proposal of 19 November 2025 to simplify and delay parts of the Act; provisional trilogue agreement reached 7 May 2026, deferring the high-risk deadlines above and adding an Article 5 prohibition on AI generating non-consensual intimate imagery and CSAM. Formal adoption and Official Journal publication were still pending at time of writing — verify current status before relying on these dates
+   - *Resources*: [Commission overview](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | [Article explorer](https://artificialintelligenceact.eu/ai-act-explorer/) (unofficial)
 
-2. 📄 [Executive Order 14110 on Safe, Secure, and Trustworthy AI](https://www.whitehouse.gov/briefing-room/presidential-actions/2023/10/30/executive-order-on-the-safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence/) (US, 2023)
-   - *Why*: Most comprehensive US federal AI policy; establishes reporting requirements for large models
+2. 📄 [General-Purpose AI Code of Practice](https://digital-strategy.ec.europa.eu/en/policies/contents-code-gpai) (European Commission, 2025)
+   - *Why*: The practical bridge between the AI Act's GPAI obligations and what providers actually have to do; signing it earns streamlined compliance and more predictable enforcement
+   - *Structure*: Three chapters — Transparency, Copyright, and Safety and Security
+   - *Status*: Published 10 July 2025, ahead of GPAI obligations applying on 2 August 2025; voluntary, with signatories published by the Commission
+
+### United States — Federal
+
+US federal AI policy reversed direction in January 2025. The entries below are ordered chronologically so the shift is legible; two are retained despite being rescinded because the successor orders are written against them.
+
+3. 📄 [National AI Initiative Act](https://www.ai.gov/) (US, 2021)
+   - *Why*: Establishes national AI strategy, funding, and coordination
+   - *Key bodies*: National AI Initiative Office; National AI Advisory Committee
+
+4. 📄 [Blueprint for an AI Bill of Rights](https://bidenwhitehouse.archives.gov/ostp/ai-bill-of-rights/) (US, 2022)
+   - *Why*: Non-binding principles for AI design and deployment in the US
+   - *Five principles*: Safe and effective systems; algorithmic discrimination protections; data privacy; notice and explanation; human alternatives
+   - *Practical tools*: [Full text and technical companion (PDF)](https://bidenwhitehouse.archives.gov/wp-content/uploads/2022/10/Blueprint-for-an-AI-Bill-of-Rights.pdf)
+   - *Status*: **Withdrawn** - removed from whitehouse.gov in January 2025; archived copy linked. Retained here for historical context, as it shaped several state laws that outlived it
+
+5. 📄 [Executive Order 14110 on Safe, Secure, and Trustworthy AI](https://www.federalregister.gov/documents/2023/11/01/2023-24283/safe-secure-and-trustworthy-development-and-use-of-artificial-intelligence) (US, 2023)
+   - *Why*: The most comprehensive US federal AI policy to date; established reporting requirements for large models and set the 10^26 FLOP threshold that state frontier-AI laws later adopted
    - *Key mandates*:
      - Safety testing for models trained with >10^26 FLOPs
      - Red-teaming requirements
      - Watermarking for AI-generated content
      - Standards development via NIST
-   - *Agency actions*: Directs all federal agencies to develop AI governance
+   - *Status*: **Revoked** 20 January 2025 by EO 14148; superseded by EO 14179. Downstream agency work it triggered (AI use-case inventories, NIST standards activity) largely survived the revocation
+   - *Note*: Federal Register copy linked; the original White House page is gone
 
-3. 📄 [Blueprint for an AI Bill of Rights](https://www.whitehouse.gov/ostp/ai-bill-of-rights/) (US, 2022)
-   - *Why*: Non-binding principles for AI design and deployment in the US
-   - *Five principles*: Safe and effective systems; algorithmic discrimination protections; data privacy; notice and explanation; human alternatives
-   - *Practical tools*: [Technical companion](https://www.whitehouse.gov/ostp/ai-bill-of-rights/technical-companion/)
+6. 📄 [Executive Order 14179: Removing Barriers to American Leadership in Artificial Intelligence](https://www.federalregister.gov/documents/2025/01/31/2025-02172/removing-barriers-to-american-leadership-in-artificial-intelligence) (US, 2025)
+   - *Why*: **The pivot point in US federal AI policy** - replaces EO 14110's safety-and-equity framing with an innovation-and-competitiveness mandate; directs agencies to review and roll back prior AI policies
+   - *Consequences*: Triggered removal of EEOC and DOL AI guidance; mandated an AI action plan within 180 days
+   - *Date*: Signed 23 January 2025
 
-4. 📄 [National AI Initiative Act](https://www.ai.gov/) (US, 2021)
-   - *Why*: Establishes national AI strategy, funding, and coordination
-   - *Key bodies*: National AI Initiative Office; National AI Advisory Committee
+7. 📄 [OMB M-25-21: Accelerating Federal Use of AI through Innovation, Governance, and Public Trust](https://www.whitehouse.gov/wp-content/uploads/2025/02/M-25-21-Accelerating-Federal-Use-of-AI-through-Innovation-Governance-and-Public-Trust.pdf) (Office of Management and Budget, 2025)
+   - *Why*: The operative rulebook for how federal agencies actually adopt AI - matters more day-to-day than the executive orders it implements
+   - *Scope*: Agency AI governance structures, minimum practices for high-impact AI use cases, Chief AI Officer responsibilities
 
-5. 📄 [China's Generative AI Regulations](http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm) (China, 2023)
-   - *Why*: First national regulation specifically for generative AI
-   - *Requirements*: Content filtering, factual accuracy, labeling of AI-generated content
-   - *Philosophical approach*: Content-focused vs. Western risk-focused frameworks
-   - *English summary*: [Stanford HAI](https://hai.stanford.edu/policy/chinas-generative-ai-regulations)
+8. 📄 [Winning the AI Race: America's AI Action Plan](https://www.ai.gov/action-plan) (US, 2025)
+   - *Why*: The policy blueprint EO 14179 ordered; sets the administration's AI agenda across innovation, infrastructure and international diplomacy
+   - *Notable*: Recommends withholding federal AI funding from states with regulation deemed burdensome - the seed of the preemption fight that followed
+   - *Date*: July 2025
 
-6. 📄 [New York State A6453A/S6953B: Training and Use of Artificial Intelligence Frontier Models](https://www.nysenate.gov/legislation/bills/2025/A6453/amendment/A) (New York, 2025)
-   - *Why*: **First US state law regulating frontier AI models** - establishes safety and transparency requirements for large AI developers
-   - *Key requirements*:
-     - Safety and security protocols for frontier models (defined as models with >10^26 FLOPs training compute)
-     - 72-hour incident reporting to state authorities
-     - Annual protocol reviews and updates
-     - Transparency requirements with appropriate redactions for trade secrets
-   - *Enforcement*: Civil penalties up to $10M (first violation) or $30M (subsequent violations)
-   - *Scope*: Applies to "large developers" deploying frontier models in New York State
-   - *Status*: Signed by Governor December 2025; effective 90 days after signing
+9. 📄 [Executive Order 14365: Ensuring a National Policy Framework for Artificial Intelligence](https://www.federalregister.gov/documents/2025/12/16/2025-23092/ensuring-a-national-policy-framework-for-artificial-intelligence) (US, 2025)
+   - *Why*: **Opens a direct federal-versus-state conflict over who regulates AI** - declares a policy of a "minimally burdensome" national standard and moves to displace inconsistent state law
+   - *Key mechanisms*:
+     - DOJ AI Litigation Task Force, operational from 10 January 2026, to challenge state AI laws in federal court
+     - Conditions certain federal funding on state regulatory posture
+   - *Carve-outs*: Expressly does not target state laws on child safety, AI compute and data-center infrastructure, or state procurement and government use of AI
+   - *Legal caveat*: Preemption ordinarily flows from congressional statute, not executive order; commentators widely expect the EO to guide federal conduct rather than independently displace state law. Litigation outcomes were unresolved at time of writing
+   - *Date*: Signed 11 December 2025
+
+### United States — State Laws
+
+With federal AI-specific legislation stalled, states became the primary source of binding US AI law. The entries below are the first-of-kind statutes that other states are modelling; see the trackers under [Practical Compliance](#practical-compliance--implementation) for the full and fast-moving picture.
+
+10. 📄 [California SB 53: Transparency in Frontier Artificial Intelligence Act (TFAIA)](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB53) (California, 2025)
+    - *Why*: **First US state statute targeting frontier AI safety and transparency** - the template New York and others followed
+    - *Key requirements*:
+      - Publish a frontier AI framework describing safety practices
+      - Publish a transparency report before releasing a new frontier model
+      - Transmit catastrophic-risk assessments to the California Office of Emergency Services
+      - Report critical safety incidents to Cal OES
+      - Whistleblower protections for covered employees
+    - *Scope*: "Frontier model" = foundation model trained on >10^26 integer or floating-point operations, including subsequent fine-tuning or material modification
+    - *Status*: Signed 29 September 2025; effective 1 January 2026
+
+11. 📄 [California SB 243: Companion Chatbots](https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB243) (California, 2025)
+    - *Why*: **First US law imposing safety duties on companion AI**, enacted in response to incidents involving minors and conversational AI; the model for a wave of 2026 chatbot bills
+    - *Key requirements*: Disclose that the user is interacting with AI; for known minors, break reminders at least every three hours; maintain a protocol addressing suicidal ideation and self-harm content with referral to crisis services; annual reporting
+    - *Status*: Signed 13 October 2025; effective 1 January 2026
+
+12. 📄 [Texas HB 149: Responsible Artificial Intelligence Governance Act (TRAIGA)](https://capitol.texas.gov/BillLookup/History.aspx?LegSess=89R&Bill=HB149) (Texas, 2025)
+    - *Why*: A deliberately narrower alternative to the EU-style risk framework - **intent-based** prohibitions rather than impact-based duties, which makes it the reference point for states resisting the Colorado model
+    - *Key provisions*: Bans AI intended for behavioral manipulation, unlawful discrimination, incitement to violence, or CSAM generation; largely limits affirmative obligations to government use; first-in-nation AI regulatory sandbox
+    - *Enforcement*: Attorney General exclusively, with notice and a 60-day cure period; no private right of action; preempts local AI ordinances
+    - *Status*: Signed 22 June 2025; effective 1 January 2026
+
+13. 📄 [Illinois HB 3773: AI in Employment (amending the Illinois Human Rights Act)](https://www.ilga.gov/Legislation/BillStatus?DocNum=3773&GAID=17&DocTypeID=HB&LegID=157807&SessionID=112) (Illinois, 2024)
+    - *Why*: Makes discriminatory AI use in employment a civil rights violation under existing state anti-discrimination machinery, rather than building a separate AI regime - a materially different regulatory strategy worth contrasting with Colorado and Texas
+    - *Key requirements*: Prohibits AI use that discriminates against protected classes across hiring, promotion, discipline and discharge; requires notice to applicants and employees when AI is used
+    - *Status*: Effective 1 January 2026
+
+14. 📄 [Utah SB 149: Artificial Intelligence Policy Act](https://le.utah.gov/~2024/bills/static/SB0149.html) (Utah, 2024)
+    - *Why*: **First US state law specifically regulating generative AI** - a minimal disclosure-based approach that predates the comprehensive frameworks
+    - *Key requirements*: Disclose generative AI use on request; 2025 amendments (SB 226, SB 332) added proactive disclosure for high-risk interactions involving health, financial or biometric data
+    - *Status*: Effective 1 May 2024; amended 2025
+
+15. 📄 [Colorado SB 26-189: Automated Decision-Making Technology](https://leg.colorado.gov/bills/sb26-189) (Colorado, 2026)
+    - *Why*: **The cautionary tale of the group** - Colorado passed the first comprehensive US state AI law (SB 24-205, 2024), delayed it twice, then repealed and replaced it before it ever took effect. Reading the two together shows what proved unworkable about impact-assessment-based regulation
+    - *What changed*: Replaces the "high-risk AI system" reasonable-care and impact-assessment regime with a narrower transparency and disclosure framework built on "covered automated decision-making technology" that materially influences consequential decisions
+    - *Key requirements*: Pre-use disclosure; explanation of adverse outcomes within 30 days; meaningful human review; documentation of training data categories and system constraints
+    - *Status*: Signed 14 May 2026; substantive obligations commence 1 January 2027, with AG rulemaking due by that date. Subject to pending litigation at time of writing
+
+16. 📄 [New York S6953B/A6453B: Responsible AI Safety and Education (RAISE) Act](https://www.nysenate.gov/legislation/bills/2025/S6953) (New York, 2025/2026)
+    - *Why*: The second state frontier-AI statute; its 2026 rewrite pulled it substantially toward California's SB 53, making the pair a good study in state-law convergence
+    - *Key requirements*: Safety and security protocols for frontier models; incident reporting; annual protocol review; published transparency documentation with trade-secret redactions
+    - *Scope*: Developers with annual revenue over $500M, for models trained with >10^26 operations and over $100M in compute cost
+    - *Oversight*: Rulemaking assigned to a new office within the New York Department of Financial Services
+    - *Status*: Originally signed 19 December 2025; the operative text is the **chapter amendment signed 27 March 2026**. Effective 1 January 2027 - one year after SB 53
+
+### Other Jurisdictions
+
+17. 📄 [China's Generative AI Regulations](http://www.cac.gov.cn/2023-07/13/c_1690898327029107.htm) (China, 2023)
+    - *Why*: First national regulation specifically for generative AI
+    - *Requirements*: Content filtering, factual accuracy, labeling of AI-generated content
+    - *Philosophical approach*: Content-focused vs. Western risk-focused frameworks
+    - *English summary*: [Stanford HAI](https://hai.stanford.edu/policy/chinas-generative-ai-regulations)
+
+18. 📄 [Measures for Labeling AI-Generated Synthetic Content](https://www.cac.gov.cn/2025-03/14/c_1743654684782215.htm) (Cyberspace Administration of China, 2025)
+    - *Why*: Turns AI content labeling from principle into a concrete build requirement - **both visible labels and embedded metadata/watermark provenance**, which is further than any Western regime has gone in binding law
+    - *Status*: Effective 1 September 2025
+    - *Context*: Pairs with algorithm registration and security self-assessment obligations already in force
+
+19. 📄 [Framework Act on Artificial Intelligence Development and Trust Base Creation](https://www.law.go.kr/LSW/eng/engLsSc.do?menuId=2&query=ARTIFICIAL+INTELLIGENCE) (South Korea, 2025)
+    - *Why*: **Second jurisdiction after the EU with a comprehensive horizontal AI statute** - the clearest test of whether the EU model travels
+    - *Key requirements*: Obligations for high-impact AI across designated sectors; fairness and non-discrimination duties; AI-generated content labeling
+    - *Status*: Effective 22 January 2026, with a grace period through 2026 during which administrative fines are generally deferred except in serious cases
+
+20. 📄 [India AI Governance Guidelines](https://www.indiaai.gov.in/) (Ministry of Electronics and IT, 2025)
+    - *Why*: The most prominent **light-touch** alternative - explicitly declines a standalone AI act, relying on existing law plus voluntary measures; useful contrast to the EU and Korean approaches
+    - *Status*: Released November 2025. Not enforceable law; AI is governed through the Digital Personal Data Protection Act and sector rules
+    - *Note*: Verify the current guideline URL on the IndiaAI portal, which reorganizes frequently
+
+21. 📄 Brazil PL 2338/2023: Proposed AI Framework (Brazil, pending)
+    - *Why*: Closely tracks the EU AI Act's risk-based structure; the leading test of whether that model is adopted across Latin America
+    - *Status*: **Not yet law.** Approved by the Senate 10 December 2024; under consideration in the Chamber of Deputies at time of writing. Included here as pending legislation, not a binding instrument
 
 ---
 
@@ -119,21 +230,37 @@
    - *Why*: **The definitive US AI risk management framework** - voluntary but increasingly expected by regulators
    - *Structure*: Four core functions: Govern, Map, Measure, Manage
    - *Risk types*: Covers technical, societal, legal, reputational risks
-   - *Practical tools*: [Playbook](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook), [risk assessment templates](https://www.nist.gov/itl/ai-risk-management-framework/ai-rmf-resources)
+   - *Practical tools*: [Playbook](https://airc.nist.gov/AI_RMF_Knowledge_Base/Playbook)
    - *Companion docs*: Addresses trustworthiness (fairness, robustness, transparency, etc.)
 
-2. 📄 [ISO/IEC 42001: AI Management System](https://www.iso.org/standard/81230.html) (ISO/IEC, 2023)
+2. 📄 [NIST AI 600-1: Generative AI Profile](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf) (NIST, 2024)
+   - *Why*: **The companion profile that makes the AI RMF usable for generative systems** - the framework alone predates the GenAI risk surface
+   - *Risks addressed*: Confabulation, harmful content generation, privacy, cybersecurity, intellectual property
+   - *Structure*: Suggested actions organized around governance, content provenance, pre-deployment testing and incident disclosure, mapped back to the RMF's GOVERN/MAP/MEASURE/MANAGE functions
+   - *Date*: Published 26 July 2024
+
+3. 📄 [Center for AI Standards and Innovation (CAISI)](https://www.nist.gov/aisi) (NIST, ongoing)
+   - *Why*: The US government's technical AI evaluation body; its outputs feed the standards regulators reference
+   - *Note*: Renamed from the US AI Safety Institute in mid-2025 - the rename tracked the broader federal shift from safety framing to standards-and-innovation framing
+   - *Recent work*: AI Agent Standards Initiative, announced February 2026
+
+4. 📄 [ISO/IEC 42001: AI Management System](https://www.iso.org/standard/81230.html) (ISO/IEC, 2023)
    - *Why*: International certifiable standard for AI management systems
    - *Scope*: Organizational governance, not individual models
    - *Certification*: Organizations can be ISO 42001 certified
-   - *Note*: [Purchase required](https://www.iso.org/standard/81230.html) | [Overview available](https://www.iso.org/news/ref2896.html)
+   - *Note*: [Purchase required](https://www.iso.org/standard/81230.html) | [Overview available](https://www.iso.org/artificial-intelligence/ai-management-systems)
 
-3. 📄 [ISO/IEC 23053: Framework for AI Systems Using ML](https://www.iso.org/standard/74438.html) (ISO/IEC, 2022)
+5. 📄 [ISO/IEC 42005: AI System Impact Assessment](https://www.iso.org/standard/44545.html) (ISO/IEC, 2025)
+   - *Why*: Gives the impact-assessment step a standardized shape - increasingly the mechanism regulations point to when they require one
+   - *Relationship*: Designed to be used alongside ISO/IEC 42001
+   - *Note*: Purchase required
+
+6. 📄 [ISO/IEC 23053: Framework for AI Systems Using ML](https://www.iso.org/standard/74438.html) (ISO/IEC, 2022)
    - *Why*: Technical standard for ML system development lifecycle
    - *Coverage*: Data quality, model development, deployment, monitoring
    - *Note*: [Purchase required](https://www.iso.org/standard/74438.html)
 
-4. 📄 [IEEE 7000 Series on AI Ethics](https://standards.ieee.org/featured/artificial-intelligence-systems/) (IEEE, Ongoing)
+7. 📄 [IEEE 7000 Series on AI Ethics](https://standards.ieee.org/initiatives/autonomous-intelligence-systems/standards/) (IEEE, Ongoing)
    - *Why*: Technical standards for embedding ethics into system design
    - *Key standards*:
      - IEEE 7000: Systems engineering for ethical concerns
@@ -141,7 +268,7 @@
      - IEEE 7002: Data privacy
    - *Approach*: Values-based engineering
 
-5. 📄 [OECD AI Principles](https://oecd.ai/en/ai-principles) (OECD, 2019)
+8. 📄 [OECD AI Principles](https://oecd.ai/en/ai-principles) (OECD, 2019)
    - *Why*: First intergovernmental AI policy standards; adopted by 40+ countries
    - *Five principles*: Inclusive growth; human-centered values; transparency; robustness; accountability
    - *Implementation*: [National AI policies dashboard](https://oecd.ai/en/dashboards)
@@ -160,7 +287,7 @@
    - *Key innovation*: "Predetermined Change Control Plans" for continuously learning models
    - *Requirements*: Clinical validation, performance monitoring, algorithm change protocols
 
-2. 📄 [EU Medical Device Regulation (MDR) & In-Vitro Diagnostic Regulation (IVDR)](https://health.ec.europa.eu/medical-devices-sector/new-regulations_en) (EU, 2017/2022)
+2. 📄 [EU Medical Device Regulation (MDR) & In-Vitro Diagnostic Regulation (IVDR)](https://health.ec.europa.eu/medical-devices-new-regulations_en) (EU, 2017/2022)
    - *Why*: AI diagnostic tools must comply; high scrutiny for "black box" algorithms
    - *Risk classification*: Most AI diagnostics are Class IIa or higher
 
@@ -170,10 +297,12 @@
 
 ### Employment & HR
 
-4. 📄 [EEOC Guidance on AI and Discrimination](https://www.eeoc.gov/laws/guidance/what-you-should-know-about-using-artificial-intelligence-when-making-employment) (EEOC, 2023)
+4. 📄 [EEOC Guidance on AI and Title VII Adverse Impact](https://web.archive.org/web/20240527151347/https://www.eeoc.gov/laws/guidance/select-issues-assessing-adverse-impact-software-algorithms-and-artificial) (EEOC, 2023)
    - *Why*: Clarifies how US employment discrimination laws apply to AI hiring tools
    - *Key point*: Employers liable for discriminatory AI, even from third-party vendors
    - *Requirements*: Validation studies, adverse impact analysis
+   - *Companion*: [ADA and AI guidance](https://web.archive.org/web/20240529055014/https://www.eeoc.gov/laws/guidance/americans-disabilities-act-and-use-software-algorithms-and-artificial-intelligence) (EEOC, 2022)
+   - *Status*: **Withdrawn** - both documents were removed from the EEOC site in 2025 following EO 14179; archived copies linked. The underlying law did not change: Title VII, the ADEA and the ADA still apply to AI-assisted employment decisions. Several states legislated into the resulting federal gap (see Illinois HB 3773 above)
 
 5. 📄 [NYC Local Law 144 (Automated Employment Decision Tools)](https://www.nyc.gov/site/dca/about/automated-employment-decision-tools.page) (NYC, 2023)
    - *Why*: First US law specifically regulating AI in hiring
@@ -181,7 +310,7 @@
 
 ### Criminal Justice
 
-6. 📄 [Algorithmic Accountability in Criminal Justice (Various state laws)](https://www.ncsl.org/technology-and-communication/algorithmic-accountability-laws)
+6. 📄 [Algorithmic Accountability in Criminal Justice (Various state laws)](https://www.ncsl.org/technology-and-communication/artificial-intelligence-2025-legislation)
    - *Why*: Many states restrict or require transparency for risk assessment tools
    - *Examples*: California AB 2542, Wisconsin's Loomis decision
 
@@ -196,15 +325,16 @@
    - *Why*: Government perspective on open model policies and dual-use concerns
    - *Note*: Official NTIA government report - freely available
 
-2. 📄 [Export Controls on AI & Emerging Technologies](https://www.bis.gov/index.php/emerging-tech-and-ai-controls) (US Bureau of Industry and Security, Ongoing)
+2. 📄 [Export Controls on AI & Emerging Technologies](https://www.bis.doc.gov/index.php/policy-guidance/advanced-computing-and-semiconductor-manufacturing-items) (US Bureau of Industry and Security, Ongoing)
    - *Why*: Controls on exporting AI chips (GPUs), training techniques, and potentially models
    - *2022 updates*: Restrictions on advanced chip exports to China
    - *Ongoing*: Potential controls on model weights, training data
 
-3. 📄 [NSCAI Final Report](https://www.nscai.gov/2021-final-report/) (National Security Commission on AI, 2021)
+3. 📄 [NSCAI Final Report](https://web.archive.org/web/20240104154550/https://www.nscai.gov/2021-final-report/) (National Security Commission on AI, 2021)
    - *Why*: Comprehensive US national security strategy for AI
    - *Key recommendations*: Defend democratic values; invest in R&D; build international partnerships
-   - *Length*: 750+ pages; [Executive summary](https://www.nscai.gov/wp-content/uploads/2021/03/Executive-Summary.pdf) available
+   - *Length*: 750+ pages
+   - *Note*: The Commission's domain was decommissioned after it sunset; archived copy linked
 
 4. 📄 [Blueprint for an AI Bill of Rights Concerning National Security Systems](https://www.dni.gov/index.php/newsroom/reports-publications) (US, 2023)
    - *Why*: Principles for AI use in intelligence and defense
@@ -238,7 +368,7 @@
 
 5. 📄 [Microsoft Responsible AI Standard](https://www.microsoft.com/en-us/ai/responsible-ai) (Microsoft, 2022)
    - *Why*: Corporate AI governance framework from major AI provider
-   - *Public version*: [v2 published 2022](https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE5cmFl)
+   - *Public version*: [Principles and approach](https://www.microsoft.com/en-us/ai/principles-and-approach)
    - *Structure*: Goals, requirements, tools, governance
 
 6. 📄 [Google's AI Principles](https://ai.google/responsibility/principles/) (Google, 2018)
@@ -259,32 +389,41 @@
 - **[Microsoft HAX Toolkit](https://www.microsoft.com/en-us/haxtoolkit/)** - Human-AI experience design patterns
 
 ### Audit & Testing
-- **[NIST AI Bias Assessment](https://pages.nist.gov/ACE/)** - Algorithmic bias testing
+- **[NIST SP 1270: Managing Bias in AI](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.1270.pdf)** - Standard for identifying and managing algorithmic bias
 - **[Aequitas](http://aequitas.dssg.io/)** - Open-source bias audit toolkit
 - **[AI Verify](https://aiverifyfoundation.sg/)** - Singapore's AI testing framework
 
 ### Documentation Templates
 - **Model Cards** - [Hugging Face template](https://huggingface.co/docs/hub/model-cards)
 - **Data Cards** - [Google template](https://sites.research.google/datacardsplaybook/)
-- **AI Impact Assessments** - [Ada Lovelace Institute](https://www.adalovelaceinstitute.org/report/algorithmic-impact-assessment-a-case-study-in-healthcare/)
+- **AI Impact Assessments** - [Ada Lovelace Institute](https://www.adalovelaceinstitute.org/report/algorithmic-impact-assessment-case-study-healthcare/)
 
 ### Legal Resources
 - **[Stanford HAI Policy Hub](https://hai.stanford.edu/policy)** - Tracking global AI policy
 - **[OECD AI Policy Observatory](https://oecd.ai/)** - International policy database
 - **[AlgorithmWatch](https://algorithmwatch.org/)** - Automated decision-making accountability
 
+### US State Legislation Trackers
+State AI law moves faster than any curated list can. Use these for current status rather than relying on the entries above:
+- **[MultiState AI Legislation Tracker](https://www.multistate.ai/artificial-intelligence-ai-legislation)** - All 50 states, updated continuously
+- **[NCSL AI Legislation Summary](https://www.ncsl.org/technology-and-communication/artificial-intelligence-2025-legislation)** - Enacted legislation by state and session
+
+**2026 trend lines worth watching**: algorithmic pricing restrictions (California AB 325, New York S.7882, Connecticut HB 8002); second-generation employment-AI rules moving from disclosure to audit and anti-discrimination duties; laws barring AI from implying licensed-professional status in healthcare; and expanded non-consensual deepfake provisions.
+
 ---
 
 ## Key Takeaways
 
 1. **Multi-jurisdictional complexity**: AI systems often face overlapping regulations across geographies and sectors
-2. **Risk-based approach emerging**: Most frameworks categorize AI by risk level with proportional requirements
-3. **Documentation is critical**: Model cards, datasheets, impact assessments increasingly expected or required
-4. **Human oversight emphasized**: Most frameworks require meaningful human involvement in high-stakes decisions
-5. **Accountability clearly assigned**: Organizations can't hide behind "the algorithm did it"
-6. **Transparency vs. IP tension**: Balancing explainability requirements with proprietary interests
-7. **Continuous monitoring**: One-time validation insufficient; ongoing performance monitoring required
-8. **Interdisciplinary teams**: Compliance requires legal, technical, and domain expertise
+2. **Risk-based approach emerging**: Most frameworks categorize AI by risk level with proportional requirements — though Texas and India show that a light-touch or intent-based alternative is actively contested, not settled
+3. **The ground shifts under you**: between 2024 and 2026 the EU deferred its high-risk deadlines, the US federal posture reversed and then moved to preempt the states, Colorado repealed its own landmark law before it took effect, and two federal guidance documents were withdrawn outright. Treat every effective date as provisional and check the primary source
+4. **US regulation is currently state regulation**: with federal AI legislation stalled, binding US obligations come mostly from states — and are now the subject of an explicit federal preemption effort (EO 14365)
+5. **Documentation is critical**: Model cards, datasheets, impact assessments increasingly expected or required
+6. **Human oversight emphasized**: Most frameworks require meaningful human involvement in high-stakes decisions
+7. **Accountability clearly assigned**: Organizations can't hide behind "the algorithm did it"
+8. **Transparency vs. IP tension**: Balancing explainability requirements with proprietary interests
+9. **Continuous monitoring**: One-time validation insufficient; ongoing performance monitoring required
+10. **Interdisciplinary teams**: Compliance requires legal, technical, and domain expertise
 
 ---
 

--- a/learning/probabilistic.md
+++ b/learning/probabilistic.md
@@ -10,7 +10,7 @@
 1. [A Probabilistic Programming Approach to Probabilistic Data Analysis](https://papers.nips.cc/paper/6060-a-probabilistic-programming-approach-to-probabilistic-data-analysis.pdf) (2016)
    - *Why*: **Automating statistical modeling** - demonstrates that probabilistic programs can express and automatically infer complex statistical models for data analysis tasks; replaces hand-derived inference algorithms with general-purpose probabilistic programming, making Bayesian data analysis accessible to non-experts
 
-2. [Picture: An Imperative Probabilistic Programming Language for Scene Perception](https://openaccess.thecvf.com/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf) (2015)
+2. [Picture: An Imperative Probabilistic Programming Language for Scene Perception](https://www.cv-foundation.org/openaccess/content_cvpr_2015/papers/Kulkarni_Picture_A_Probabilistic_2015_CVPR_paper.pdf) (2015)
    - *Why*: Probabilistic programming for computer vision; demonstrates analysis-by-synthesis
 
 3. [Encapsulating Models and Approximate Inference Programs in Probabilistic Modules](https://arxiv.org/abs/1612.04759) (2016)
@@ -37,7 +37,7 @@
 1. [Approximate Bayesian Image Interpretation using Generative Probabilistic Graphics Programs](http://papers.nips.cc/paper/4881-approximate-bayesian-image-interpretation-using-generative-probabilistic-graphics-programs.pdf) (2013)
    - *Why*: **Inverse graphics as Bayesian inference** - treats scene understanding as inverting a graphics rendering pipeline: given an image, infer the 3D scene (objects, poses, lighting) that most likely produced it; uses probabilistic programming to express the generative model as a renderer and performs approximate posterior inference over scene parameters
 
-2. 🔒 [A Bayesian Framework for Modeling Intuitive Dynamics](https://cocosci.berkeley.edu/tom/papers/collisions.pdf) (2009)
+2. [A Bayesian Framework for Modeling Intuitive Dynamics](https://cocosci.princeton.edu/tom/papers/collisions.pdf) (2009)
    - *Why*: **Bayesian models of intuitive physics** - formalizes human physical intuition (predicting collisions, stability, trajectories) as approximate Bayesian inference over a mental physics simulator; explains systematic biases in human physical reasoning as rational under uncertainty; foundational for cognitive science approaches to physical reasoning in AI
    - *Note*: Institutional repository - may require access
 

--- a/learning/safety.md
+++ b/learning/safety.md
@@ -126,7 +126,7 @@ As AI systems control increasingly important decisions—from content moderation
 2. [Sleeper Agents: Training Deceptive LLMs That Persist Through Safety Training](https://arxiv.org/abs/2401.05566) (Hubinger et al., 2024)
    - *Why*: **Critical deceptive alignment research** - demonstrates that LLMs can be trained with hidden behaviors that persist through safety training; shows current safety techniques may be insufficient for detecting deceptive models; essential for understanding alignment challenges
 
-3. [Scalable Oversight](https://www.anthropic.com/research/scalable-oversight) (Anthropic, 2022)
+3. [Scalable Oversight](https://www.anthropic.com/research/measuring-progress-on-scalable-oversight-for-large-language-models) (Anthropic, 2022)
    - *Why*: **Key long-term safety challenge** - addresses how to supervise AI systems that may become more capable than their human supervisors; explores techniques like debate, recursive reward modeling, and amplification
    - *Note*: Research blog post from Anthropic; foundational concept in AI safety
 


### PR DESCRIPTION
Full audit of `learning/policy.md` against the 2025–2026 regulatory landscape, plus the index corrections that surfaced while checking the READMEs.

## Why

The policy area was written against a pre-2025 landscape. Three independent problems had accumulated: link rot, factual drift, and — unrelated to policy — index files that misreport what the repo contains.

## Factual corrections

| Was | Actually |
|---|---|
| EO 14110 presented as current US federal policy | Revoked 20 Jan 2025 by EO 14148, superseded by EO 14179 |
| NY law billed as "first US state law regulating frontier AI models" | **California SB 53 was first** — signed 29 Sept 2025, effective a year ahead of NY |
| NY entry: Dec 2025 text, "effective 90 days after signing" | Operative text is the **27 Mar 2026 chapter amendment**; effective **1 Jan 2027**; scope now >$500M revenue + >$100M compute cost, DFS rulemaking |
| EU AI Act "applicable from 2026" | Staged: prohibitions Feb 2025, GPAI Aug 2025, Art. 50 Aug 2026, Annex III deferred to **Dec 2027**, Annex I to **Aug 2028** |
| EU AI Act "official text" → `CELEX:52021PC0206` | That's the **2021 proposal**, not the law. Now the ELI URL for Reg. (EU) 2024/1689 |
| AI Bill of Rights + EEOC guidance shown as live | Both **withdrawn in 2025** — kept with status notes and archival links |

## New sources — 21 entries, verified primary sources

- **US federal**: EO 14179, OMB M-25-21, America's AI Action Plan, EO 14365 (DOJ AI Litigation Task Force / state preemption)
- **US states** (new subsection): CA SB 53, CA SB 243, TX HB 149 (TRAIGA), IL HB 3773, UT SB 149, and CO SB 26-189 — which **repealed and replaced the 2024 Colorado AI Act before it ever took effect**
- **International**: CoE Framework Convention on AI (CETS 225, in force 1 Nov 2025), Korea Framework Act, China AI labeling measures, India MeitY guidelines, Brazil PL 2338 (**marked pending — not law**)
- **Standards**: NIST AI 600-1, CAISI, EU GPAI Code of Practice, ISO/IEC 42005
- **Trackers**: MultiState and NCSL, for the long tail — 29 states enacted AI legislation in 2026 alone, so the curated entries are the first-of-kind laws only

## Link rot

**22 of 67** policy URLs were dead. All repaired; archival copies where the source is genuinely gone (OCC/Fed model risk guidance, NSCAI, the withdrawn federal guidance).

## Index corrections

Found while auditing the READMEs — unrelated to policy but in the same files:

- **Every per-area count in README was stale.** Total claimed 237; actual is 267
- **Glossary advertised "250+ terms" in three places.** It has **160**
- Date range said 1997-2025; `by-date.md` runs to 2026
- Three further dead links (scalable oversight, Picture/CVPR, Berkeley collisions PDF), each duplicated across files

## Verification

- All **293** links in the touched files resolve. The only non-200s are publisher and government hosts that block automated requests (ACM, SAGE, SSRN, Cell, coe.int, nysenate.gov, hhs.gov) — these were 403 before this change too and are not breakage.
- Counts recomputed from the tree and reconciled against every figure in README.
- Numbering verified strictly sequential in every `policy.md` section.

## Notes

- Effective dates are the most volatile field here; the section now carries a dated "verify before relying on this" callout.
- The EU Digital Omnibus had provisional agreement 7 May 2026 with formal adoption pending — worded to stay true either way.
- Nothing in this repo checks links or counts, which is how 22 dead links and a 90-term overclaim accumulated unnoticed. A CI job walking every markdown link (with an allowlist for the known 403 publishers) would prevent the next backlog — happy to add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)